### PR TITLE
Sling 7591

### DIFF
--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrProviderStateFactory.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrProviderStateFactory.java
@@ -140,14 +140,17 @@ public class JcrProviderStateFactory {
     }
 
     private JcrProviderState createJcrProviderState(
-            @Nonnull final Session s,
+            @Nonnull final Session session,
             final boolean logoutSession,
             @Nonnull final Map<String, Object> authenticationInfo,
             @Nullable final BundleContext ctx
     ) throws LoginException {
-        final Session session = handleImpersonation(s, authenticationInfo, logoutSession);
+        final Session impersonatedSession = handleImpersonation(session, authenticationInfo, logoutSession);
+        // if we're actually impersonating, we're responsible for closing the session we've created, regardless
+        // of what the original logoutSession value was.
+        boolean doLogoutSession = logoutSession || (impersonatedSession != session);
         final HelperData data = new HelperData(this.dynamicClassLoaderManagerReference, this.uriProviderReference);
-        return new JcrProviderState(session, data, logoutSession, ctx, ctx == null ? null : repositoryReference);
+        return new JcrProviderState(impersonatedSession, data, doLogoutSession, ctx, ctx == null ? null : repositoryReference);
     }
 
     /**

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProviderTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProviderTest.java
@@ -62,18 +62,18 @@ public class JcrResourceProviderTest extends RepositoryTestBase {
     }
     
     public void testLeakOnSudo() throws LoginException, RepositoryException, NamingException {
-    	Repository repo = getRepository();
-    	ComponentContext ctx = Mockito.mock(ComponentContext.class);
-    	Mockito.when(ctx.locateService(Mockito.anyString(), Mockito.any(ServiceReference.class))).thenReturn(repo);
-    	jcrResourceProvider = new JcrResourceProvider();
-    	jcrResourceProvider.activate(ctx);
-    	Map<String, Object> authInfo = new HashMap<String, Object>();
-    	authInfo.put(JcrResourceConstants.AUTHENTICATION_INFO_SESSION, session);
-    	authInfo.put(ResourceResolverFactory.USER_IMPERSONATION, "anonymous");
-		JcrProviderState providerState = jcrResourceProvider.authenticate(authInfo);
-		Assert.assertNotEquals("Impersonation didn't start new session", session, providerState.getSession());
-		jcrResourceProvider.logout(providerState);
-		assertFalse("Impersonated session wasn't closed.", providerState.getSession().isLive());
+        Repository repo = getRepository();
+        ComponentContext ctx = Mockito.mock(ComponentContext.class);
+        Mockito.when(ctx.locateService(Mockito.anyString(), Mockito.any(ServiceReference.class))).thenReturn(repo);
+        jcrResourceProvider = new JcrResourceProvider();
+        jcrResourceProvider.activate(ctx);
+        Map<String, Object> authInfo = new HashMap<String, Object>();
+        authInfo.put(JcrResourceConstants.AUTHENTICATION_INFO_SESSION, session);
+        authInfo.put(ResourceResolverFactory.USER_IMPERSONATION, "anonymous");
+        JcrProviderState providerState = jcrResourceProvider.authenticate(authInfo);
+        Assert.assertNotEquals("Impersonation didn't start new session", session, providerState.getSession());
+        jcrResourceProvider.logout(providerState);
+        assertFalse("Impersonated session wasn't closed.", providerState.getSession().isLive());
     }
 }
 

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProviderTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProviderTest.java
@@ -19,13 +19,23 @@
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
 import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
 
+import javax.jcr.Repository;
+import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.naming.NamingException;
 
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.commons.testing.jcr.RepositoryTestBase;
+import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 import org.apache.sling.spi.resource.provider.ResolveContext;
 import org.junit.Assert;
 import org.mockito.Mockito;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.ComponentContext;
 
 public class JcrResourceProviderTest extends RepositoryTestBase {
 
@@ -49,6 +59,21 @@ public class JcrResourceProviderTest extends RepositoryTestBase {
         ResolveContext ctx = Mockito.mock(ResolveContext.class);
         Mockito.when(ctx.getProviderState()).thenReturn(new JcrProviderState(session, null, false));
         Assert.assertNotNull(jcrResourceProvider.adaptTo(ctx, Principal.class));
+    }
+    
+    public void testLeakOnSudo() throws LoginException, RepositoryException, NamingException {
+    	Repository repo = getRepository();
+    	ComponentContext ctx = Mockito.mock(ComponentContext.class);
+    	Mockito.when(ctx.locateService(Mockito.anyString(), Mockito.any(ServiceReference.class))).thenReturn(repo);
+    	jcrResourceProvider = new JcrResourceProvider();
+    	jcrResourceProvider.activate(ctx);
+    	Map<String, Object> authInfo = new HashMap<String, Object>();
+    	authInfo.put(JcrResourceConstants.AUTHENTICATION_INFO_SESSION, session);
+    	authInfo.put(ResourceResolverFactory.USER_IMPERSONATION, "anonymous");
+		JcrProviderState providerState = jcrResourceProvider.authenticate(authInfo);
+		Assert.assertNotEquals("Impersonation didn't start new session", session, providerState.getSession());
+		jcrResourceProvider.logout(providerState);
+		assertFalse("Impersonated session wasn't closed.", providerState.getSession().isLive());
     }
 }
 


### PR DESCRIPTION
SLING-7591: Fix session leak on impersonation

Make sure that if a JCR ResourceResolver opens a new session for
impersonation, it also closes that session on close().