### PR TITLE
SLING-3524: Clone JCR session when a resource resolver is cloned.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.16.4</version>
+            <version>2.18.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrProviderStateFactory.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrProviderStateFactory.java
@@ -181,7 +181,9 @@ public class JcrProviderStateFactory {
     private static Session handleImpersonation(final Session session, final Map<String, Object> authenticationInfo,
             final boolean logoutSession, boolean explicitSessionUsed) throws LoginException {
         final String sudoUser = getSudoUser(authenticationInfo);
+        // Do we need session.impersonate() because we are asked to impersonate another user?
         boolean needsSudo = (sudoUser != null) && !session.getUserID().equals(sudoUser);
+        // Do we need session.impersonate() to get an independent copy of the session we were given in the auth info?
         boolean needsCloning = !needsSudo && explicitSessionUsed && authenticationInfo.containsKey(ResourceProvider.AUTH_CLONE);
         if (needsCloning || needsSudo) {
             // If we just need to clone the session, we impersonate with the same user ID and not set an impersonator attribute.

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrProviderStateFactory.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrProviderStateFactory.java
@@ -145,7 +145,12 @@ public class JcrProviderStateFactory {
             @Nonnull final Map<String, Object> authenticationInfo,
             @Nullable final BundleContext ctx
     ) throws LoginException {
-        final Session impersonatedSession = handleImpersonation(session, authenticationInfo, logoutSession);
+        boolean explicitSessionUsed = (getSession(authenticationInfo) != null);
+        final Session impersonatedSession = handleImpersonation(session, authenticationInfo, logoutSession, explicitSessionUsed);
+        if (impersonatedSession != session && explicitSessionUsed) {
+            // update the session in the auth info map in case the resolver gets cloned in the future
+            authenticationInfo.put(JcrResourceConstants.AUTHENTICATION_INFO_SESSION, impersonatedSession);
+        }
         // if we're actually impersonating, we're responsible for closing the session we've created, regardless
         // of what the original logoutSession value was.
         boolean doLogoutSession = logoutSession || (impersonatedSession != session);
@@ -167,18 +172,26 @@ public class JcrProviderStateFactory {
      * @param logoutSession
      *            whether to logout the <code>session</code> after impersonation
      *            or not.
+     * @param explicitSessionUsed
+     *            whether the JCR session was explicitly given in the auth info or not.
      * @return The original session or impersonated session.
      * @throws LoginException
      *             If something goes wrong.
      */
     private static Session handleImpersonation(final Session session, final Map<String, Object> authenticationInfo,
-            final boolean logoutSession) throws LoginException {
+            final boolean logoutSession, boolean explicitSessionUsed) throws LoginException {
         final String sudoUser = getSudoUser(authenticationInfo);
-        if (sudoUser != null && !session.getUserID().equals(sudoUser)) {
+        boolean needsSudo = (sudoUser != null) && !session.getUserID().equals(sudoUser);
+        boolean needsCloning = !needsSudo && explicitSessionUsed && authenticationInfo.containsKey(ResourceProvider.AUTH_CLONE);
+        if (needsCloning || needsSudo) {
+            // If we just need to clone the session, we impersonate with the same user ID and not set an impersonator attribute.
+            // In all other cases, it's a "proper" sudo to the given user.
             try {
-                final SimpleCredentials creds = new SimpleCredentials(sudoUser, new char[0]);
+                final SimpleCredentials creds = new SimpleCredentials(needsSudo ? sudoUser : session.getUserID(), new char[0]);
                 copyAttributes(creds, authenticationInfo);
-                creds.setAttribute(ResourceResolver.USER_IMPERSONATOR, session.getUserID());
+                if (needsSudo) {
+                    creds.setAttribute(ResourceResolver.USER_IMPERSONATOR, session.getUserID());
+                }
                 return session.impersonate(creds);
             } catch (final RepositoryException re) {
                 throw getLoginException(re);

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProviderSessionHandlingTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProviderSessionHandlingTest.java
@@ -1,0 +1,180 @@
+package org.apache.sling.jcr.resource.internal.helper.jcr;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeThat;
+import static org.junit.Assume.assumeTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.jcr.Session;
+
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.commons.testing.jcr.RepositoryProvider;
+import org.apache.sling.jcr.api.SlingRepository;
+import org.apache.sling.jcr.resource.api.JcrResourceConstants;
+import org.apache.sling.spi.resource.provider.ResolveContext;
+import org.apache.sling.spi.resource.provider.ResourceProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.mockito.Mockito;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.ComponentContext;
+
+@RunWith(Parameterized.class)
+public class JcrResourceProviderSessionHandlingTest {
+
+    private enum LoginStyle {USER, SESSION};
+
+    private static final String AUTH_USER = "admin";
+    private static final char[] AUTH_PASSWORD = "admin".toCharArray();
+    private static final String SUDO_USER = "anonymous";
+
+    @Parameters(name = "loginStyle= {0}, sudo = {1}, clone = {2}")
+    public static List<Object[]> data() {
+
+        LoginStyle[] loginStyles = LoginStyle.values();
+        boolean[] sudoOptions = new boolean[] {false, true};
+        boolean[] cloneOptions = new boolean[] {false, true};
+
+        // Generate all possible combinations into data.
+        List<Object[]> data = new ArrayList<>();
+        Object[] dataPoint = new Object[3];
+        for (LoginStyle loginStyle : loginStyles) {
+            dataPoint[0] = loginStyle;
+            for (boolean sudo : sudoOptions) {
+                dataPoint[1] = sudo;
+                for (boolean clone : cloneOptions) {
+                    dataPoint[2] = clone;
+                    data.add(dataPoint.clone());
+                }
+            }
+        }
+        return data;
+    }
+
+    @Parameter(0)
+    public LoginStyle loginStyle;
+
+    @Parameter(1)
+    public boolean useSudo;
+
+    @Parameter(2)
+    public boolean doClone;
+
+    // Session we're using when loginStyle == SESSION, null otherwise.
+    private Session explicitSession;
+
+    private JcrResourceProvider jcrResourceProvider;
+    private JcrProviderState jcrProviderState;
+
+    @Before
+    public void setUp() throws Exception {
+        SlingRepository repo = RepositoryProvider.instance().getRepository();
+        Map<String, Object> authInfo = new HashMap<>();
+        switch (loginStyle) {
+        case USER:
+            authInfo.put(ResourceResolverFactory.USER, AUTH_USER);
+            authInfo.put(ResourceResolverFactory.PASSWORD, AUTH_PASSWORD);
+            break;
+        case SESSION:
+            explicitSession = repo.loginAdministrative(null);
+            authInfo.put(JcrResourceConstants.AUTHENTICATION_INFO_SESSION, explicitSession);
+            break;
+        }
+
+        if (useSudo) {
+            authInfo.put(ResourceResolverFactory.USER_IMPERSONATION, SUDO_USER);
+        }
+
+        if (doClone) {
+            authInfo.put(ResourceProvider.AUTH_CLONE, true);
+        }
+
+        ComponentContext ctx = mock(ComponentContext.class);
+        when(ctx.locateService(anyString(), Mockito.<ServiceReference<Object>>any())).thenReturn(repo);
+
+        jcrResourceProvider = new JcrResourceProvider();
+        jcrResourceProvider.activate(ctx);
+
+        jcrProviderState = jcrResourceProvider.authenticate(authInfo);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+        // Some tests do a logout, so check for liveness before trying to log out.
+        if (jcrProviderState.getSession().isLive()) {
+            jcrResourceProvider.logout(jcrProviderState);
+        }
+
+        jcrResourceProvider.deactivate();
+
+        if (explicitSession != null) {
+            explicitSession.logout();
+        }
+    }
+
+    @Test
+    public void sessionUsesCorrectUser() {
+        String expectedUser = useSudo ? SUDO_USER : AUTH_USER;
+        assertEquals(expectedUser, jcrProviderState.getSession().getUserID());
+    }
+
+    @Test
+    public void explicitSessionNotClosedOnLogout() {
+        assumeTrue(loginStyle == LoginStyle.SESSION);
+
+        jcrResourceProvider.logout(jcrProviderState);
+
+        assertTrue(explicitSession.isLive());
+    }
+
+    @Test
+    public void sessionsDoNotLeak() {
+        // This test is only valid if we either didn't pass an explicit session,
+        // or the provider had to clone it. Sessions created by the provider
+        // must be closed by the provider, or we have a session leak.
+        assumeThat(jcrProviderState.getSession(), is(not(sameInstance(explicitSession))));
+
+        jcrResourceProvider.logout(jcrProviderState);
+
+        assertFalse(jcrProviderState.getSession().isLive());
+    }
+
+    @Test
+    public void impersonatorIsReportedCorrectly() {
+        assumeTrue(useSudo);
+
+        @SuppressWarnings("unchecked")
+        ResolveContext<JcrProviderState> mockContext = mock(ResolveContext.class);
+        when(mockContext.getProviderState()).thenReturn(jcrProviderState);
+        Object reportedImpersonator = jcrResourceProvider.getAttribute(mockContext, ResourceResolver.USER_IMPERSONATOR);
+
+        assertEquals(AUTH_USER, reportedImpersonator);
+    }
+
+    @Test
+    public void clonesAreIndependent() {
+        assumeTrue(loginStyle == LoginStyle.SESSION && doClone);
+
+        assertNotSame(explicitSession, jcrProviderState.getSession());
+    }
+
+}

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProviderTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProviderTest.java
@@ -19,20 +19,12 @@
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
 import java.security.Principal;
-import java.util.HashMap;
-import java.util.Map;
 
 import javax.jcr.Repository;
-import javax.jcr.RepositoryException;
 import javax.jcr.Session;
-import javax.naming.NamingException;
 
-import org.apache.sling.api.resource.LoginException;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.commons.testing.jcr.RepositoryTestBase;
-import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 import org.apache.sling.spi.resource.provider.ResolveContext;
-import org.apache.sling.spi.resource.provider.ResourceProvider;
 import org.junit.Assert;
 import org.mockito.Mockito;
 import org.osgi.framework.ServiceReference;
@@ -65,25 +57,6 @@ public class JcrResourceProviderTest extends RepositoryTestBase {
         ResolveContext ctx = Mockito.mock(ResolveContext.class);
         Mockito.when(ctx.getProviderState()).thenReturn(new JcrProviderState(session, null, false));
         Assert.assertNotNull(jcrResourceProvider.adaptTo(ctx, Principal.class));
-    }
-
-    public void testLeakOnSudo() throws LoginException, RepositoryException, NamingException {
-        Map<String, Object> authInfo = new HashMap<String, Object>();
-        authInfo.put(JcrResourceConstants.AUTHENTICATION_INFO_SESSION, session);
-        authInfo.put(ResourceResolverFactory.USER_IMPERSONATION, "anonymous");
-        JcrProviderState providerState = jcrResourceProvider.authenticate(authInfo);
-        Assert.assertNotEquals("Impersonation didn't start new session", session, providerState.getSession());
-        jcrResourceProvider.logout(providerState);
-        assertFalse("Impersonated session wasn't closed.", providerState.getSession().isLive());
-    }
-
-    public void testNoSessionSharing() throws LoginException {
-        Map<String, Object> authInfo = new HashMap<String, Object>();
-        authInfo.put(JcrResourceConstants.AUTHENTICATION_INFO_SESSION, session);
-        authInfo.put(ResourceProvider.AUTH_CLONE, true);
-        JcrProviderState providerState = jcrResourceProvider.authenticate(authInfo);
-        Assert.assertNotEquals("Cloned resolver didn't clone session.", session, providerState.getSession());
-        jcrResourceProvider.logout(providerState);
     }
 }
 


### PR DESCRIPTION
Detect when a session-based resource resolver is being cloned, and clone
the underlying JCR session using the self-impersonation trick. This
requires slight API changes in order to detect cloning.

The necessary API changes require two other pull requests to be merged. To avoid repeating myself, I'll update the corresponding JIRA ticket with the reasoning, and with the links of the other requests.