### PR TITLE
Strings and Boxed types should be compared using "equals()"

### DIFF
--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrNodeResource.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrNodeResource.java
@@ -109,7 +109,7 @@ class JcrNodeResource extends JcrItemResource<Node> { // this should be package 
     @Override
     public String getResourceSuperType() {
         // Yes, this isn't how you're supposed to compare Strings, but this is intentional.
-        if ( resourceSuperType == UNSET_RESOURCE_SUPER_TYPE ) {
+        if ( resourceSuperType.equals(UNSET_RESOURCE_SUPER_TYPE) ) {
             try {
                 if (getNode().hasProperty(JcrResourceConstants.SLING_RESOURCE_SUPER_TYPE_PROPERTY)) {
                     resourceSuperType = getNode().getProperty(JcrResourceConstants.SLING_RESOURCE_SUPER_TYPE_PROPERTY).getValue().getString();
@@ -117,7 +117,7 @@ class JcrNodeResource extends JcrItemResource<Node> { // this should be package 
             } catch (RepositoryException re) {
                 // we ignore this
             }
-            if ( resourceSuperType == UNSET_RESOURCE_SUPER_TYPE ) {
+            if ( resourceSuperType.equals(UNSET_RESOURCE_SUPER_TYPE) ) {
                 resourceSuperType = null;
             }
         }


### PR DESCRIPTION
This fixes 2 Sonarqube violations of rule S4973:
https://rules.sonarsource.com/java/RSPEC-4973

Sonarcloud violation URL:
https://sonarcloud.io/organizations/apache/issues?languages=java&open=AWo-VD1YK1LJlmpkjcwg&resolved=false&rules=squid%3AS4973&types=BUG

Jira Ticket:
https://issues.apache.org/jira/browse/SLING-8825