### PR TITLE
SLING-11454 : Add missing notnull/nullable annotations

### DIFF
--- a/src/main/java/org/apache/sling/jcr/resource/internal/HelperData.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/HelperData.java
@@ -25,6 +25,8 @@ import javax.jcr.Session;
 
 import org.apache.sling.api.resource.external.URIProvider;
 import org.apache.sling.commons.classloader.DynamicClassLoaderManager;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * This is a helper class used to pass several services/data to the resource
@@ -39,19 +41,20 @@ public class HelperData {
 
     private volatile String[] namespacePrefixes;
 
-    public HelperData(final AtomicReference<DynamicClassLoaderManager> dynamicClassLoaderManagerReference, AtomicReference<URIProvider[]> uriProviderReference) {
+    public HelperData(final @NotNull AtomicReference<DynamicClassLoaderManager> dynamicClassLoaderManagerReference,
+                      @NotNull AtomicReference<URIProvider[]> uriProviderReference) {
         this.dynamicClassLoaderManagerReference = dynamicClassLoaderManagerReference;
         this.uriProviderReference = uriProviderReference;
     }
 
-    public String[] getNamespacePrefixes(final Session session) throws RepositoryException {
+    public @NotNull String[] getNamespacePrefixes(final @NotNull Session session) throws RepositoryException {
         if (this.namespacePrefixes == null) {
             this.namespacePrefixes = session.getNamespacePrefixes();
         }
         return this.namespacePrefixes;
     }
 
-    public ClassLoader getDynamicClassLoader() {
+    public @Nullable ClassLoader getDynamicClassLoader() {
         final DynamicClassLoaderManager dclm = this.dynamicClassLoaderManagerReference.get();
         if (dclm == null) {
             return null;
@@ -59,7 +62,7 @@ public class HelperData {
         return dclm.getDynamicClassLoader();
     }
 
-    public URIProvider[] getURIProviders() {
+    public @NotNull URIProvider[] getURIProviders() {
         URIProvider[] ups = this.uriProviderReference.get();
         if (ups == null) {
             ups = EMPTY_URLPROVIDERS;

--- a/src/main/java/org/apache/sling/jcr/resource/internal/JcrListenerBaseConfig.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/JcrListenerBaseConfig.java
@@ -36,6 +36,7 @@ import org.apache.sling.api.resource.path.Path;
 import org.apache.sling.jcr.api.SlingRepository;
 import org.apache.sling.spi.resource.provider.ObservationReporter;
 import org.apache.sling.spi.resource.provider.ObserverConfiguration;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +53,7 @@ public class JcrListenerBaseConfig implements Closeable {
     private final ObservationReporter reporter;
 
     @SuppressWarnings("deprecation")
-    public JcrListenerBaseConfig(final ObservationReporter reporter, final SlingRepository repository) throws RepositoryException {
+    public JcrListenerBaseConfig(final @NotNull ObservationReporter reporter, final @NotNull SlingRepository repository) throws RepositoryException {
         this.reporter = reporter;
         // The session should have read access on the whole repository
         this.session = repository.loginService("observation", repository.getDefaultWorkspace());
@@ -179,7 +180,7 @@ public class JcrListenerBaseConfig implements Closeable {
      * The observation reporter
      * @return The observation reporter.
      */
-    public ObservationReporter getReporter() {
+    public @NotNull ObservationReporter getReporter() {
         return this.reporter;
     }
 }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/JcrModifiableValueMap.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/JcrModifiableValueMap.java
@@ -40,7 +40,7 @@ public class JcrModifiableValueMap extends JcrValueMap implements ModifiableValu
      * @param node The underlying node.
      * @param helper Helper data object
      */
-    public JcrModifiableValueMap(final Node node, final HelperData helper) {
+    public JcrModifiableValueMap(final @NotNull Node node, final @NotNull HelperData helper) {
         super(node, helper);
     }
 

--- a/src/main/java/org/apache/sling/jcr/resource/internal/JcrValueMap.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/JcrValueMap.java
@@ -39,6 +39,7 @@ import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.jcr.resource.internal.helper.JcrPropertyMapCacheEntry;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * This implementation of the value map allows to change
@@ -66,7 +67,7 @@ public class JcrValueMap implements ValueMap {
      * @param node The underlying node.
      * @param helper Helper data object
      */
-    public JcrValueMap(final Node node, final HelperData helper) {
+    public JcrValueMap(final @NotNull Node node, final @NotNull HelperData helper) {
         this.node = node;
         this.helper = helper;
     }
@@ -231,7 +232,7 @@ public class JcrValueMap implements ValueMap {
      * @return A JcrPropertyMapCacheEntry for the given property
      * @throws IllegalArgumentException if a repository exception occurs
      */
-    private JcrPropertyMapCacheEntry cacheProperty(final Property prop) {
+    private @NotNull JcrPropertyMapCacheEntry cacheProperty(final @NotNull Property prop) {
         try {
             // calculate the key
             final String name = prop.getName();
@@ -267,7 +268,7 @@ public class JcrValueMap implements ValueMap {
      * Read a single property.
      * @throws IllegalArgumentException if a repository exception occurs
      */
-    JcrPropertyMapCacheEntry read(final String name) {
+    @Nullable JcrPropertyMapCacheEntry read(final @NotNull String name) {
         // check for empty key
         if (name.length() == 0) {
             return null;
@@ -353,7 +354,7 @@ public class JcrValueMap implements ValueMap {
      * @return escaped key name
      * @throws RepositoryException if the repository's namespace prefixes cannot be retrieved
      */
-    protected String escapeKeyName(final String key) throws RepositoryException {
+    protected @NotNull String escapeKeyName(final @NotNull String key) throws RepositoryException {
         final int indexOfPrefix = key.indexOf(':');
         // check if colon is neither the first nor the last character
         if (indexOfPrefix > 0 && key.length() > indexOfPrefix + 1) {
@@ -404,7 +405,7 @@ public class JcrValueMap implements ValueMap {
         return type;
     }
 
-    private static Map<String, Object> transformEntries(final Map<String, JcrPropertyMapCacheEntry> map) {
+    private static @NotNull Map<String, Object> transformEntries(final @NotNull Map<String, JcrPropertyMapCacheEntry> map) {
 
         final Map<String, Object> transformedEntries = new LinkedHashMap<>(map.size());
         for (final Map.Entry<String, JcrPropertyMapCacheEntry> entry : map.entrySet())

--- a/src/main/java/org/apache/sling/jcr/resource/internal/NodeUtil.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/NodeUtil.java
@@ -37,6 +37,7 @@ import javax.jcr.RepositoryException;
 import javax.jcr.nodetype.NodeType;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class NodeUtil {
     
@@ -49,7 +50,7 @@ public abstract class NodeUtil {
      * @param mixinTypes the mixins
      * @throws RepositoryException if the repository's namespaced prefixes cannot be retrieved
      */
-    public static void handleMixinTypes(final Node node, final String[] mixinTypes) throws RepositoryException {
+    public static void handleMixinTypes(final @NotNull Node node, final @Nullable String[] mixinTypes) throws RepositoryException {
         final Set<String> newTypes = new HashSet<>();
         if (mixinTypes != null) {
             Collections.addAll(newTypes, mixinTypes);

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/BooleanConverter.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/BooleanConverter.java
@@ -18,6 +18,8 @@
  */
 package org.apache.sling.jcr.resource.internal.helper;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
@@ -49,54 +51,54 @@ public class BooleanConverter implements Converter {
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toLong()
      */
-    public Long toLong() {
+    public @NotNull Long toLong() {
         return this.getNumber().longValue();
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toByte()
      */
-    public Byte toByte() {
+    public @NotNull Byte toByte() {
         return this.getNumber().byteValue();
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toShort()
      */
-    public Short toShort() {
+    public @NotNull Short toShort() {
         return this.getNumber().shortValue();
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toInteger()
      */
-    public Integer toInteger() {
+    public @NotNull Integer toInteger() {
         return this.getNumber().intValue();
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toDouble()
      */
-    public Double toDouble() {
+    public @NotNull Double toDouble() {
         return this.getNumber().doubleValue();
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toFloat()
      */
-    public Float toFloat() {
+    public @NotNull Float toFloat() {
         return this.getNumber().floatValue();
     }
 
     @Override
-    public ZonedDateTime toZonedDateTime() {
+    public @NotNull ZonedDateTime toZonedDateTime() {
         return new CalendarConverter(toCalendar()).toZonedDateTime();
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toCalendar()
      */
-    public Calendar toCalendar() {
+    public @NotNull Calendar toCalendar() {
         final Calendar c = Calendar.getInstance();
         c.setTimeInMillis(this.toLong());
         return c;
@@ -105,21 +107,21 @@ public class BooleanConverter implements Converter {
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toDate()
      */
-    public Date toDate() {
+    public @NotNull Date toDate() {
         return new Date(this.toLong());
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toBoolean()
      */
-    public Boolean toBoolean() {
+    public @NotNull Boolean toBoolean() {
         return this.value;
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toBigDecimal()
      */
-    public BigDecimal toBigDecimal() {
+    public @NotNull BigDecimal toBigDecimal() {
         return new BigDecimal(this.getNumber().toString());
     }
 }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/CalendarConverter.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/CalendarConverter.java
@@ -23,6 +23,7 @@ import java.util.Calendar;
 import java.util.Date;
 
 import org.apache.jackrabbit.util.ISO8601;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A converter for Calendar
@@ -37,7 +38,7 @@ public class CalendarConverter extends NumberConverter implements Converter {
     }
 
     @Override
-    public ZonedDateTime toZonedDateTime() {
+    public @NotNull ZonedDateTime toZonedDateTime() {
         return ZonedDateTime.ofInstant(this.value.toInstant(), this.value.getTimeZone().toZoneId().normalized());
     }
 
@@ -45,7 +46,7 @@ public class CalendarConverter extends NumberConverter implements Converter {
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toCalendar()
      */
     @Override
-    public Calendar toCalendar() {
+    public @NotNull Calendar toCalendar() {
         return this.value;
     }
 
@@ -53,7 +54,7 @@ public class CalendarConverter extends NumberConverter implements Converter {
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toDate()
      */
     @Override
-    public Date toDate() {
+    public @NotNull Date toDate() {
         return this.value.getTime();
     }
 

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/Converter.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/Converter.java
@@ -18,12 +18,12 @@
  */
 package org.apache.sling.jcr.resource.internal.helper;
 
+import org.jetbrains.annotations.NotNull;
 
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Date;
-
 
 /**
  * A converter converts a value to a specific target type.
@@ -35,75 +35,75 @@ public interface Converter {
      * @return Long representation of the converted value
      * @throws NumberFormatException if the conversion fails
      */
-    Long toLong();
+    @NotNull Long toLong();
 
     /**
      * Convert to Byte.
      * @return Byte representation of the converted value
      * @throws NumberFormatException if the conversion fails
      */
-    Byte toByte();
+    @NotNull Byte toByte();
 
     /**
      * Convert to Short.
      * @return Short representation of the converted value
      * @throws NumberFormatException if the conversion fails
      */
-    Short toShort();
+    @NotNull Short toShort();
 
     /**
      * Convert to Integer.
      * @return Integer representation of the converted value
      * @throws NumberFormatException if the conversion fails
      */
-    Integer toInteger();
+    @NotNull Integer toInteger();
 
     /**
      * Convert to Double.
      * @return Double representation of the converted value
      * @throws NumberFormatException if the conversion fails
      */
-    Double toDouble();
+    @NotNull Double toDouble();
 
     /**
      * Convert to Float.
      * @return Float representation of the converted value
      * @throws NumberFormatException if the conversion fails
      */
-    Float toFloat();
+    @NotNull Float toFloat();
 
     /**
      * Convert to ZonedDateTime.
      * @return Calendar representation of the converted value
      * @throws IllegalArgumentException  if the value cannot be parsed into a calendar
      */
-    ZonedDateTime toZonedDateTime();
+    @NotNull ZonedDateTime toZonedDateTime();
 
     /**
      * Convert to Calendar.
      * @return Calendar representation of the converted value
      * @throws IllegalArgumentException  if the value cannot be parsed into a calendar
      */
-    Calendar toCalendar();
+    @NotNull Calendar toCalendar();
 
     /**
      * Convert to Date.
      * @return Date representation of the converted value
      * @throws IllegalArgumentException  if the value cannot be parsed into a date
      */
-    Date toDate();
+    @NotNull Date toDate();
 
     /**
      * Convert to boolean.
      * @return  Boolean representation of the converted value
      */
-    Boolean toBoolean();
+    @NotNull Boolean toBoolean();
 
     /**
      * Convert to BigDecimal.
      * @return BigDecimal representation of the converted value
      * @throws NumberFormatException if the conversion fails
      */
-    BigDecimal toBigDecimal();
+    @NotNull BigDecimal toBigDecimal();
 
 }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/DateConverter.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/DateConverter.java
@@ -23,6 +23,7 @@ import java.util.Calendar;
 import java.util.Date;
 
 import org.apache.jackrabbit.util.ISO8601;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A converter for Date
@@ -37,7 +38,7 @@ public class DateConverter extends NumberConverter implements Converter {
     }
 
     @Override
-    public ZonedDateTime toZonedDateTime() {
+    public @NotNull ZonedDateTime toZonedDateTime() {
         return new CalendarConverter(toCalendar()).toZonedDateTime();
     }
 
@@ -45,7 +46,7 @@ public class DateConverter extends NumberConverter implements Converter {
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toCalendar()
      */
     @Override
-    public Calendar toCalendar() {
+    public @NotNull Calendar toCalendar() {
         final Calendar c = Calendar.getInstance();
         c.setTimeInMillis(this.toLong());
         return c;
@@ -55,7 +56,7 @@ public class DateConverter extends NumberConverter implements Converter {
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toDate()
      */
     @Override
-    public Date toDate() {
+    public @NotNull Date toDate() {
         return this.value;
     }
 

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/JcrPropertyMapCacheEntry.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/JcrPropertyMapCacheEntry.java
@@ -42,6 +42,8 @@ import javax.jcr.Value;
 import javax.jcr.ValueFormatException;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +67,7 @@ public class JcrPropertyMapCacheEntry {
      * @param prop the property
      * @throws RepositoryException if the provided property cannot be converted to a Java Object
      */
-    public JcrPropertyMapCacheEntry(final Property prop) throws RepositoryException {
+    public JcrPropertyMapCacheEntry(final @NotNull Property prop) throws RepositoryException {
         this.property = prop;
         this.isArray = prop.isMultiple();
         if (property.getType() != PropertyType.BINARY) {
@@ -203,9 +205,9 @@ public class JcrPropertyMapCacheEntry {
      * @return The converted object
      */
     @SuppressWarnings("unchecked")
-    public <T> T convertToType(final Class<T> type,
-                               final Node node,
-                               final ClassLoader dynamicClassLoader) {
+    public <T> T convertToType(final @NotNull Class<T> type,
+                               final @NotNull Node node,
+                               final @Nullable ClassLoader dynamicClassLoader) {
         T result = null;
 
         try {
@@ -240,10 +242,10 @@ public class JcrPropertyMapCacheEntry {
         return result;
     }
 
-    private <T> T[] convertToArray(final Object[] sourceArray,
-                                   final Class<T> type,
-                                   final Node node,
-                                   final ClassLoader dynamicClassLoader) throws RepositoryException {
+    private <T> T[] convertToArray(final @NotNull Object[] sourceArray,
+                                   final @NotNull Class<T> type,
+                                   final @NotNull Node node,
+                                   final @Nullable ClassLoader dynamicClassLoader) throws RepositoryException {
         List<T> values = new ArrayList<>();
         for (int i = 0; i < sourceArray.length; i++) {
             T value = convertToType(i, sourceArray[i], type, node, dynamicClassLoader);
@@ -260,10 +262,10 @@ public class JcrPropertyMapCacheEntry {
 
     @SuppressWarnings("unchecked")
     private <T> T convertToType(final int index,
-                                final Object initialValue,
-                                final Class<T> type,
-                                final Node node,
-                                final ClassLoader dynamicClassLoader) throws RepositoryException {
+                                final @NotNull Object initialValue,
+                                final @NotNull Class<T> type,
+                                final @NotNull Node node,
+                                final @Nullable ClassLoader dynamicClassLoader) throws RepositoryException {
         if (type.isInstance(initialValue)) {
             return (T) initialValue;
         }
@@ -414,7 +416,7 @@ public class JcrPropertyMapCacheEntry {
 
         private final ClassLoader classloader;
 
-        public PropertyObjectInputStream(final InputStream in, final ClassLoader classLoader) throws IOException {
+        public PropertyObjectInputStream(final @NotNull InputStream in, final @Nullable ClassLoader classLoader) throws IOException {
             super(in);
             this.classloader = classLoader;
         }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/JcrResourceUtil.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/JcrResourceUtil.java
@@ -18,6 +18,9 @@
  */
 package org.apache.sling.jcr.resource.internal.helper;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
@@ -52,7 +55,7 @@ public class JcrResourceUtil {
      * @return the query's result
      * @throws RepositoryException if the {@link QueryManager} cannot be retrieved
      */
-    public static QueryResult query(Session session, String query, String language) throws RepositoryException {
+    public static @NotNull QueryResult query(@NotNull Session session, @NotNull String query, @NotNull String language) throws RepositoryException {
         QueryManager qManager = session.getWorkspace().getQueryManager();
         Query q = qManager.createQuery(query, language);
         return q.execute();
@@ -65,7 +68,7 @@ public class JcrResourceUtil {
      * @return the Java Object
      * @throws RepositoryException if the value cannot be converted
      */
-    public static Object toJavaObject(Value value) throws RepositoryException {
+    public static @NotNull Object toJavaObject(@NotNull Value value) throws RepositoryException {
         switch (value.getType()) {
             case PropertyType.DECIMAL:
                 return value.getDecimal();
@@ -98,7 +101,7 @@ public class JcrResourceUtil {
      * @throws RepositoryException if the conversion cannot take place
      * @return the Object resulting from the conversion
      */
-    public static Object toJavaObject(Property property)
+    public static @NotNull Object toJavaObject(@NotNull Property property)
             throws RepositoryException {
         // multi-value property: return an array of values
         if (property.isMultiple()) {
@@ -144,7 +147,7 @@ public class JcrResourceUtil {
      * @return the value or null if not convertible to a valid PropertyType
      * @throws RepositoryException in case of error, accessing the Repository
      */
-    public static Value createValue(final Object value, final Session session) throws RepositoryException {
+    public static @Nullable Value createValue(final @NotNull Object value, final @NotNull Session session) throws RepositoryException {
         Value val;
         ValueFactory fac = session.getValueFactory();
         if (value instanceof ZonedDateTime) {

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/LazyInputStream.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/LazyInputStream.java
@@ -18,6 +18,8 @@
  */
 package org.apache.sling.jcr.resource.internal.helper;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -36,7 +38,7 @@ public class LazyInputStream extends InputStream {
     /** The inputstream created on demand, null if not used */
     private InputStream delegatee;
 
-    public LazyInputStream(Value value) {
+    public LazyInputStream(@NotNull Value value) {
         this.value = value;
     }
 
@@ -100,7 +102,7 @@ public class LazyInputStream extends InputStream {
     }
 
     /** Actually retrieves the input stream from the underlying JCR Value */
-    private InputStream getStream() throws IOException {
+    private @NotNull InputStream getStream() throws IOException {
         if (delegatee == null) {
             try {
                 delegatee = value.getBinary().getStream();

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/NumberConverter.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/NumberConverter.java
@@ -18,6 +18,8 @@
  */
 package org.apache.sling.jcr.resource.internal.helper;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
@@ -45,54 +47,54 @@ public class NumberConverter implements Converter {
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toLong()
      */
-    public Long toLong() {
+    public @NotNull Long toLong() {
         return this.value.longValue();
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toByte()
      */
-    public Byte toByte() {
+    public @NotNull Byte toByte() {
         return this.value.byteValue();
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toShort()
      */
-    public Short toShort() {
+    public @NotNull Short toShort() {
         return this.value.shortValue();
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toInteger()
      */
-    public Integer toInteger() {
+    public @NotNull Integer toInteger() {
         return this.value.intValue();
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toDouble()
      */
-    public Double toDouble() {
+    public @NotNull Double toDouble() {
         return this.value.doubleValue();
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toFloat()
      */
-    public Float toFloat() {
+    public @NotNull Float toFloat() {
         return this.value.floatValue();
     }
 
     @Override
-    public ZonedDateTime toZonedDateTime() {
+    public @NotNull ZonedDateTime toZonedDateTime() {
         return new CalendarConverter(toCalendar()).toZonedDateTime();
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toCalendar()
      */
-    public Calendar toCalendar() {
+    public @NotNull Calendar toCalendar() {
         final Calendar c = Calendar.getInstance();
         c.setTimeInMillis(this.toLong());
         return c;
@@ -101,21 +103,21 @@ public class NumberConverter implements Converter {
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toDate()
      */
-    public Date toDate() {
+    public @NotNull Date toDate() {
         return new Date(this.toLong());
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toBoolean()
      */
-    public Boolean toBoolean() {
+    public @NotNull Boolean toBoolean() {
         return false;
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toBigDecimal()
      */
-    public BigDecimal toBigDecimal() {
+    public @NotNull BigDecimal toBigDecimal() {
         if (this.value instanceof BigDecimal) {
             return (BigDecimal) this.value;
         }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/StringConverter.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/StringConverter.java
@@ -24,6 +24,7 @@ import java.util.Calendar;
 import java.util.Date;
 
 import org.apache.jackrabbit.util.ISO8601;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A converter for any object based on toString()
@@ -47,54 +48,54 @@ public class StringConverter implements Converter {
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toLong()
      */
-    public Long toLong() {
+    public @NotNull Long toLong() {
         return Long.parseLong(this.toString());
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toByte()
      */
-    public Byte toByte() {
+    public @NotNull Byte toByte() {
         return Byte.parseByte(this.toString());
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toShort()
      */
-    public Short toShort() {
+    public @NotNull Short toShort() {
         return Short.parseShort(this.toString());
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toInteger()
      */
-    public Integer toInteger() {
+    public @NotNull Integer toInteger() {
         return Integer.parseInt(this.toString());
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toDouble()
      */
-    public Double toDouble() {
+    public @NotNull Double toDouble() {
         return Double.parseDouble(this.toString());
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toFloat()
      */
-    public Float toFloat() {
+    public @NotNull Float toFloat() {
         return Float.parseFloat(this.toString());
     }
 
     @Override
-    public ZonedDateTime toZonedDateTime() {
+    public @NotNull ZonedDateTime toZonedDateTime() {
         return new CalendarConverter(toCalendar()).toZonedDateTime();
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toCalendar()
      */
-    public Calendar toCalendar() {
+    public @NotNull Calendar toCalendar() {
         final Calendar c = ISO8601.parse(toString());
         if (c == null) {
             throw new IllegalArgumentException("Not a date string: " + toString());
@@ -105,7 +106,7 @@ public class StringConverter implements Converter {
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toDate()
      */
-    public Date toDate() {
+    public @NotNull Date toDate() {
         final Calendar c = this.toCalendar();
         return c.getTime();
     }
@@ -113,14 +114,14 @@ public class StringConverter implements Converter {
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toBoolean()
      */
-    public Boolean toBoolean() {
+    public @NotNull Boolean toBoolean() {
         return Boolean.valueOf(this.toString());
     }
 
     /**
      * @see org.apache.sling.jcr.resource.internal.helper.Converter#toBigDecimal()
      */
-    public BigDecimal toBigDecimal() {
+    public @NotNull BigDecimal toBigDecimal() {
         return new BigDecimal(this.toString());
     }
 }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/ZonedDateTimeConverter.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/ZonedDateTimeConverter.java
@@ -18,12 +18,14 @@
  */
 package org.apache.sling.jcr.resource.internal.helper;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.time.ZonedDateTime;
 import java.util.GregorianCalendar;
 
 public class ZonedDateTimeConverter extends CalendarConverter {
 
-    public ZonedDateTimeConverter(ZonedDateTime value) {
+    public ZonedDateTimeConverter(@NotNull ZonedDateTime value) {
         super(GregorianCalendar.from(value));
     }
 }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrExternalizableInputStream.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrExternalizableInputStream.java
@@ -58,7 +58,7 @@ public class JcrExternalizableInputStream extends InputStream implements Externa
         return getInputStream().read();
     }
 
-    private InputStream getInputStream() throws IOException {
+    private @NotNull InputStream getInputStream() throws IOException {
         if (inputStream == null) {
             try {
                 // perform lazy initialisation so that a consumer of

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrItemResource.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrItemResource.java
@@ -34,6 +34,7 @@ import org.apache.sling.api.resource.ResourceMetadata;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,11 +56,11 @@ abstract class JcrItemResource<T extends Item> // this should be package private
 
     private final ResourceMetadata metadata;
 
-    protected JcrItemResource(final ResourceResolver resourceResolver,
-                              final String path,
-                              final String version,
-                              final T item,
-                              final ResourceMetadata metadata) {
+    protected JcrItemResource(final @NotNull ResourceResolver resourceResolver,
+                              final @NotNull String path,
+                              final @Nullable String version,
+                              final @NotNull T item,
+                              final @NotNull ResourceMetadata metadata) {
 
         this.resourceResolver = resourceResolver;
         this.path = path;
@@ -105,7 +106,7 @@ abstract class JcrItemResource<T extends Item> // this should be package private
      * @return a {@link javax.jcr.Node} or a {@link javax.jcr.Property}, depending
      *         on the implementation
      */
-    protected T getItem() {
+    protected @NotNull T getItem() {
         return item;
     }
 
@@ -114,8 +115,8 @@ abstract class JcrItemResource<T extends Item> // this should be package private
      * SLING_RESOURCE_TYPE_PROPERTY, or the node's primary node type, if the
      * property is not set
      */
-    protected String getResourceTypeForNode(final Node node)
-            throws RepositoryException {
+    @NotNull
+    protected String getResourceTypeForNode(final @NotNull Node node) throws RepositoryException {
         String result = null;
 
         if (node.hasProperty(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY)) {
@@ -135,7 +136,7 @@ abstract class JcrItemResource<T extends Item> // this should be package private
         return result;
     }
 
-    public static long getContentLength(final Property property) throws RepositoryException {
+    public static long getContentLength(final @NotNull Property property) throws RepositoryException {
         if (property.isMultiple()) {
             return -1;
         }
@@ -159,6 +160,6 @@ abstract class JcrItemResource<T extends Item> // this should be package private
      * Returns an iterator over the child resources or <code>null</code> if
      * there are none.
      */
-    abstract Iterator<Resource> listJcrChildren();
+    @Nullable abstract Iterator<Resource> listJcrChildren();
 
 }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrItemResourceFactory.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrItemResourceFactory.java
@@ -51,7 +51,7 @@ public class JcrItemResourceFactory {
 
     private final boolean isJackrabbit;
 
-    public JcrItemResourceFactory(final Session session, final HelperData helper) {
+    public JcrItemResourceFactory(final @NotNull Session session, final @NotNull HelperData helper) {
         this.helper = helper;
         this.session = session;
         this.isJackrabbit = session instanceof JackrabbitSession;
@@ -68,8 +68,8 @@ public class JcrItemResourceFactory {
      * @throws RepositoryException If an error occurrs accessing checking the
      *             item in the repository.
      */
-    public JcrItemResource<?> createResource(final ResourceResolver resourceResolver, final String resourcePath,
-                                             final Resource parent, final Map<String, String> parameters) throws RepositoryException {
+    public @Nullable JcrItemResource<?> createResource(final @NotNull ResourceResolver resourceResolver, final @NotNull String resourcePath,
+                                                       final @Nullable Resource parent, final @Nullable Map<String, String> parameters) throws RepositoryException {
         if (resourcePath == null) {
             log.debug("createResource: {} maps to an empty JCR path", resourcePath);
             return null;
@@ -140,7 +140,7 @@ public class JcrItemResourceFactory {
         return null;
     }
 
-    private static Item getSubitem(Node node, String relPath) {
+    private static @Nullable Item getSubitem(@NotNull Node node, @NotNull String relPath) {
         try {
             if (relPath.length() == 0) { // not using isEmpty() due to 1.5 compatibility
                 return node;
@@ -157,7 +157,7 @@ public class JcrItemResourceFactory {
         }
     }
 
-    private Node getFrozenNode(Node node, String versionSpecifier) throws RepositoryException {
+    private @Nullable Node getFrozenNode(@NotNull Node node, @NotNull String versionSpecifier) throws RepositoryException {
         final VersionManager versionManager = session.getWorkspace().getVersionManager();
         final VersionHistory history = versionManager.getVersionHistory(node.getPath());
         if (history.hasVersionLabel(versionSpecifier)) {
@@ -169,11 +169,11 @@ public class JcrItemResourceFactory {
         }
     }
 
-    private static boolean isVersionable(Item item) throws RepositoryException {
+    private static boolean isVersionable(@NotNull Item item) throws RepositoryException {
         return item.isNode() && ((Node) item).isNodeType(NodeType.MIX_VERSIONABLE);
     }
 
-    Item getItemOrNull(String path) {
+    @Nullable Item getItemOrNull(@NotNull String path) {
         // Check first if the path is absolute. If it isn't, then we return null because the previous itemExists method,
         // which was replaced by this method, would have returned null as well (instead of throwing an exception).
         if (path.isEmpty() || path.charAt(0) != '/') {

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrNodeResourceIterator.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrNodeResourceIterator.java
@@ -29,6 +29,8 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.path.PathSet;
 import org.apache.sling.jcr.resource.internal.HelperData;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -112,12 +114,12 @@ public class JcrNodeResourceIterator implements Iterator<Resource> {
         throw new UnsupportedOperationException();
     }
 
-    private Resource seek() {
+    private @Nullable Resource seek() {
         while (nodes.hasNext()) {
             try {
                 final Node n = nodes.nextNode();
                 final String path = getPath(n);
-                if (path != null && this.excludedPaths.matches(path) == null) {
+                if (this.excludedPaths.matches(path) == null) {
                     final Resource resource = new JcrNodeResource(resourceResolver,
                             path, parentVersion, n, helper);
                     LOGGER.debug("seek: Returning Resource {}", resource);
@@ -133,7 +135,7 @@ public class JcrNodeResourceIterator implements Iterator<Resource> {
         return null;
     }
 
-    private String getPath(final Node node) throws RepositoryException {
+    private @NotNull String getPath(final @NotNull Node node) throws RepositoryException {
         final String path;
         if (parentPath == null) {
             path = node.getPath();

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrNodeResourceMetadata.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrNodeResourceMetadata.java
@@ -56,11 +56,11 @@ class JcrNodeResourceMetadata extends ResourceMetadata {
     private long creationTime = -1;
     private boolean populated = false;
 
-    public JcrNodeResourceMetadata(final Node inNode) {
+    public JcrNodeResourceMetadata(final @NotNull Node inNode) {
         this.node = inNode;
     }
 
-    private Node promoteNode() {
+    private @NotNull Node promoteNode() {
         // check stuff for nt:file nodes
         try {
             if ((!nodePromotionChecked) &&

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrPropertyResource.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrPropertyResource.java
@@ -53,10 +53,10 @@ class JcrPropertyResource extends JcrItemResource<Property> { // this should be 
 
     private final String resourceType;
 
-    public JcrPropertyResource(final ResourceResolver resourceResolver,
-                               final String path,
-                               final String version,
-                               final Property property) throws RepositoryException {
+    public JcrPropertyResource(final @NotNull ResourceResolver resourceResolver,
+                               final @NotNull String path,
+                               final @Nullable String version,
+                               final @NotNull Property property) throws RepositoryException {
         super(resourceResolver, path, version, property, new ResourceMetadata());
         this.resourceType = getResourceTypeForNode(property.getParent())
                 + "/" + property.getName();
@@ -207,11 +207,11 @@ class JcrPropertyResource extends JcrItemResource<Property> { // this should be 
         return getClass().getSimpleName() + ", type=" + getResourceType() + ", path=" + getPath();
     }
 
-    private Property getProperty() {
+    private @NotNull Property getProperty() {
         return getItem();
     }
 
-    private InputStream getInputStream() {
+    private @Nullable InputStream getInputStream() {
         Property prop = getProperty();
 
         try {
@@ -225,7 +225,7 @@ class JcrPropertyResource extends JcrItemResource<Property> { // this should be 
     }
 
     @Override
-    Iterator<Resource> listJcrChildren() {
+    @Nullable Iterator<Resource> listJcrChildren() {
         return null;
     }
 

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrProviderState.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrProviderState.java
@@ -24,6 +24,8 @@ import javax.jcr.Session;
 
 import org.apache.sling.jcr.api.SlingRepository;
 import org.apache.sling.jcr.resource.internal.HelperData;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 
@@ -41,15 +43,15 @@ class JcrProviderState implements Closeable {
 
     private final HelperData helperData;
 
-    JcrProviderState(final Session session, final HelperData helperData, final boolean logout) {
+    JcrProviderState(final @NotNull Session session, final @NotNull HelperData helperData, final boolean logout) {
         this(session, helperData, logout, null, null);
     }
 
-    JcrProviderState(final Session session,
-                     final HelperData helperData,
+    JcrProviderState(final @NotNull Session session,
+                     final @NotNull HelperData helperData,
                      final boolean logout,
-                     final BundleContext bundleContext,
-                     final ServiceReference<SlingRepository> repositoryRef) {
+                     final @Nullable BundleContext bundleContext,
+                     final @Nullable ServiceReference<SlingRepository> repositoryRef) {
         this.session = session;
         this.bundleContext = bundleContext;
         this.repositoryRef = repositoryRef;
@@ -58,15 +60,15 @@ class JcrProviderState implements Closeable {
         this.resourceFactory = new JcrItemResourceFactory(session, helperData);
     }
 
-    Session getSession() {
+    @NotNull Session getSession() {
         return session;
     }
 
-    JcrItemResourceFactory getResourceFactory() {
+    @NotNull JcrItemResourceFactory getResourceFactory() {
         return resourceFactory;
     }
 
-    HelperData getHelperData() {
+    @NotNull HelperData getHelperData() {
         return helperData;
     }
 

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrProviderStateFactory.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrProviderStateFactory.java
@@ -79,7 +79,7 @@ public class JcrProviderStateFactory {
     }
 
     @SuppressWarnings("deprecation")
-    JcrProviderState createProviderState(final @NotNull Map<String, Object> authenticationInfo) throws LoginException {
+    @NotNull JcrProviderState createProviderState(final @NotNull Map<String, Object> authenticationInfo) throws LoginException {
         boolean isLoginAdministrative = Boolean.TRUE.equals(authenticationInfo.get(ResourceProvider.AUTH_ADMIN));
 
         // check whether a session is provided in the authenticationInfo
@@ -137,9 +137,9 @@ public class JcrProviderStateFactory {
         return createJcrProviderState(session, true, authenticationInfo, bc);
     }
 
-    private JcrProviderState createJcrProviderState(@NotNull final Session session, final boolean logoutSession,
-                                                    @NotNull final Map<String, Object> authenticationInfo, 
-                                                    @Nullable final BundleContext ctx) throws LoginException {
+    private @NotNull JcrProviderState createJcrProviderState(@NotNull final Session session, final boolean logoutSession,
+                                                             @NotNull final Map<String, Object> authenticationInfo,
+                                                             @Nullable final BundleContext ctx) throws LoginException {
         boolean explicitSessionUsed = (getSession(authenticationInfo) != null);
         final Session impersonatedSession = handleImpersonation(session, authenticationInfo, logoutSession, explicitSessionUsed);
         if (impersonatedSession != session && explicitSessionUsed) {

--- a/src/test/java/org/apache/sling/jcr/resource/internal/JcrResourceListenerTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/JcrResourceListenerTest.java
@@ -42,6 +42,7 @@ import org.apache.sling.jcr.api.SlingRepository;
 import org.apache.sling.jcr.resource.internal.helper.jcr.SlingRepositoryProvider;
 import org.apache.sling.spi.resource.provider.ObservationReporter;
 import org.apache.sling.spi.resource.provider.ObserverConfiguration;
+import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -225,6 +226,7 @@ public class JcrResourceListenerTest {
             }
 
             @Override
+            @NotNull
             public Set<String> getPropertyNamesHint() {
                 return null;
             }
@@ -339,7 +341,7 @@ public class JcrResourceListenerTest {
         }
 
         @Override
-        public List<ObserverConfiguration> getObserverConfigurations() {
+        public @NotNull List<ObserverConfiguration> getObserverConfigurations() {
             ObserverConfiguration config = new ObserverConfiguration() {
 
                 @Override
@@ -376,7 +378,7 @@ public class JcrResourceListenerTest {
         }
 
         @Override
-        public void reportChanges(ObserverConfiguration config, Iterable<ResourceChange> changes, boolean distribute) {
+        public void reportChanges(@NotNull ObserverConfiguration config, @NotNull Iterable<ResourceChange> changes, boolean distribute) {
             this.reportChanges(changes, distribute);
         }
     }


### PR DESCRIPTION
@cziegeler , @joerghoh , another bunch of notnull/nullable annotations for the sling-jcr-resource bundle. except for removal of one redundant check for null in {{JcrNodeResource}}, it's just annotations.
i would appreciate if you had time for a quick review. thanks.