### PR TITLE
SLING-11449: Use latest improvements of Oak 1.44.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,8 @@
     <properties>
         <site.jira.version.id>12314286</site.jira.version.id>
         <site.javadoc.exclude>**.internal.**</site.javadoc.exclude>
-        <!-- aok 1.10.0 was first version compatible with Jackrabbit API 2.18 (https://issues.apache.org/jira/browse/OAK-7943) -->
-        <!-- aok 1.42.0 first version to include JackrabbitSession.getParentOrNull in oak-jackrabbit-api (https://issues.apache.org/jira/browse/SLING-10011) -->
-        <oak.version>1.43-SNAPSHOT</oak.version>
+        <!-- oak 1.44.0 first version to include JackrabbitNode.getPropertyOrNull in oak-jackrabbit-api (https://issues.apache.org/jira/browse/SLING-11449) -->
+        <oak.version>1.44.0</oak.version>
         <jackrabbit.version>2.18.0</jackrabbit.version><!-- required for direct binary access, https://issues.apache.org/jira/browse/JCR-4335 -->
         <project.build.outputTimestamp>1</project.build.outputTimestamp>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <site.javadoc.exclude>**.internal.**</site.javadoc.exclude>
         <!-- aok 1.10.0 was first version compatible with Jackrabbit API 2.18 (https://issues.apache.org/jira/browse/OAK-7943) -->
         <!-- aok 1.42.0 first version to include JackrabbitSession.getParentOrNull in oak-jackrabbit-api (https://issues.apache.org/jira/browse/SLING-10011) -->
-        <oak.version>1.42.0</oak.version>
+        <oak.version>1.43-SNAPSHOT</oak.version>
         <jackrabbit.version>2.18.0</jackrabbit.version><!-- required for direct binary access, https://issues.apache.org/jira/browse/JCR-4335 -->
         <project.build.outputTimestamp>1</project.build.outputTimestamp>
     </properties>

--- a/src/main/java/org/apache/sling/jcr/resource/internal/JcrModifiableValueMap.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/JcrModifiableValueMap.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import javax.jcr.Node;
+import javax.jcr.Property;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 
@@ -104,8 +105,9 @@ public class JcrModifiableValueMap extends JcrValueMap implements ModifiableValu
         final Object oldValue = this.valueCache.remove(key);
         try {
             final String name = escapeKeyName(key);
-            if (node.hasProperty(name)) {
-                node.getProperty(name).remove();
+            Property property = NodeUtil.getPropertyOrNull(node, name);
+            if (property != null) {
+                property.remove();
             }
         } catch (final RepositoryException re) {
             throw new IllegalArgumentException("Property '" + key + "' can't be removed from node '" + getPath() + "'.", re);

--- a/src/main/java/org/apache/sling/jcr/resource/internal/JcrValueMap.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/JcrValueMap.java
@@ -26,6 +26,8 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import javax.jcr.Node;
 import javax.jcr.Property;
@@ -33,6 +35,7 @@ import javax.jcr.PropertyIterator;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 
+import org.apache.jackrabbit.api.JackrabbitNode;
 import org.apache.jackrabbit.util.ISO9075;
 import org.apache.jackrabbit.util.Text;
 import org.apache.sling.api.resource.ModifiableValueMap;
@@ -278,8 +281,9 @@ public class JcrValueMap implements ValueMap {
             // encoding
             final String path = ISO9075.encodePath(name);
             try {
-                if (node.hasProperty(path)) {
-                    return new JcrPropertyMapCacheEntry(node.getProperty(path));
+                Property property = NodeUtil.getPropertyOrNull(node, path);
+                if (property != null) {
+                    return new JcrPropertyMapCacheEntry(property);
                 }
             } catch (final RepositoryException re) {
                 throw new IllegalArgumentException(re);
@@ -303,8 +307,9 @@ public class JcrValueMap implements ValueMap {
             }
             final String newPath = sb.toString();
             try {
-                if (node.hasProperty(newPath)) {
-                    return new JcrPropertyMapCacheEntry(node.getProperty(newPath));
+                Property property = NodeUtil.getPropertyOrNull(node,newPath);
+                if (property != null) {
+                    return new JcrPropertyMapCacheEntry(property);
                 }
             } catch (final RepositoryException re) {
                 throw new IllegalArgumentException(re);
@@ -321,9 +326,9 @@ public class JcrValueMap implements ValueMap {
 
         try {
             final String key = escapeKeyName(name);
-            if (node.hasProperty(key)) {
-                final Property prop = node.getProperty(key);
-                return cacheProperty(prop);
+            Property property = NodeUtil.getPropertyOrNull(node,key);
+            if (property != null) {
+                return cacheProperty(property);
             }
         } catch (final RepositoryException re) {
             throw new IllegalArgumentException(re);
@@ -333,9 +338,9 @@ public class JcrValueMap implements ValueMap {
             // for compatibility with older versions we use the (wrong) ISO9075 path
             // encoding
             final String oldKey = ISO9075.encodePath(name);
-            if (node.hasProperty(oldKey)) {
-                final Property prop = node.getProperty(oldKey);
-                return cacheProperty(prop);
+            Property property = NodeUtil.getPropertyOrNull(node,oldKey);
+            if (property != null) {
+                return cacheProperty(property);
             }
         } catch (final RepositoryException re) {
             // we ignore this

--- a/src/main/java/org/apache/sling/jcr/resource/internal/NodeUtil.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/NodeUtil.java
@@ -36,7 +36,9 @@ import javax.jcr.Property;
 import javax.jcr.RepositoryException;
 import javax.jcr.nodetype.NodeType;
 
+import org.apache.jackrabbit.api.JackrabbitNode;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class NodeUtil {
     
@@ -89,8 +91,9 @@ public abstract class NodeUtil {
                 : node.isNodeType(NT_LINKED_FILE) ? node.getProperty(JCR_CONTENT).getNode() : node;
         Property data;
         // if the node has a jcr:data property, use that property
-        if (content.hasProperty(JCR_DATA)) {
-            data = content.getProperty(JCR_DATA);
+        final Property property = getPropertyOrNull(content,JCR_DATA);
+        if (property != null) {
+            data = property;
         } else {
             // otherwise try to follow default item trail
             Item item = content.getPrimaryItem();
@@ -100,5 +103,44 @@ public abstract class NodeUtil {
             data = (Property) item;
         }
         return data;
+    }
+
+    /**
+     * Return a named property from a node.
+     *
+     * In case a recent Oak JCR version is present, it switches to an optimized
+     * version which just does one lookup of the property. This is not possible
+     * with plain JCR.
+     *
+     * @param node the node
+     * @param propertyName the property to check for
+     * @return the property if it exists, null otherwise
+     * @throws RepositoryException in case of a problem
+     */
+    public static @Nullable Property getPropertyOrNull (@NotNull Node node, @NotNull String propertyName) throws RepositoryException {
+        if (node instanceof JackrabbitNode) {
+            JackrabbitNode jnode = (JackrabbitNode) node;
+            Property prop = jnode.getPropertyOrNull(propertyName);
+            return prop;
+        } else {
+            if (node.hasProperty(propertyName)) {
+                return node.getProperty(propertyName);
+            } else {
+                return null;
+            }
+        }
+    }
+
+    public static @Nullable Node getNodeOrNull (@NotNull Node node, @NotNull String childNode) throws RepositoryException {
+        if (node instanceof JackrabbitNode) {
+            JackrabbitNode jnode = (JackrabbitNode) node;
+            return jnode.getNodeOrNull(childNode);
+        } else {
+            if (node.hasNode(childNode)) {
+                return node.getNode(childNode);
+            } else {
+                return null;
+            }
+        }
     }
 }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrItemResource.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrItemResource.java
@@ -33,6 +33,7 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceMetadata;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.jcr.resource.api.JcrResourceConstants;
+import org.apache.sling.jcr.resource.internal.NodeUtil;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -118,15 +119,17 @@ abstract class JcrItemResource<T extends Item> // this should be package private
             throws RepositoryException {
         String result = null;
 
-        if (node.hasProperty(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY)) {
-            result = node.getProperty(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY).getString();
+        Property property = NodeUtil.getPropertyOrNull(node, JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY);
+        if (property != null) {
+            result = property.getString();
         }
 
         if (result == null || result.length() == 0) {
             // Do not load the relatively expensive NodeType object unless necessary. See OAK-2441 for the reason why it
             // cannot only use getProperty here.
-            if (node.hasProperty(Property.JCR_PRIMARY_TYPE)) {
-                result = node.getProperty(Property.JCR_PRIMARY_TYPE).getString();
+            property = NodeUtil.getPropertyOrNull(node, Property.JCR_PRIMARY_TYPE);
+            if (property != null) {
+                result = property.getString();
             } else {
                 result = node.getPrimaryNodeType().getName();
             }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrItemResourceFactory.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrItemResourceFactory.java
@@ -35,6 +35,7 @@ import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.jcr.resource.internal.HelperData;
+import org.apache.sling.jcr.resource.internal.NodeUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -142,15 +143,18 @@ public class JcrItemResourceFactory {
 
     private static Item getSubitem(Node node, String relPath) {
         try {
-            if (relPath.length() == 0) { // not using isEmpty() due to 1.5 compatibility
+            if (relPath.isEmpty()) {
                 return node;
-            } else if (node.hasNode(relPath)) {
-                return node.getNode(relPath);
-            } else if (node.hasProperty(relPath)) {
-                return node.getProperty(relPath);
-            } else {
-                return null;
             }
+            Node childNode = NodeUtil.getNodeOrNull(node, relPath);
+            if (childNode != null) {
+                return childNode;
+            }
+            Property property = NodeUtil.getPropertyOrNull(node, relPath);
+            if (property != null) {
+                return property;
+            }
+            return null;
         } catch (RepositoryException e) {
             log.debug("getSubitem: Can't get subitem {} of {}: {}", relPath, node, e.toString());
             return null;
@@ -162,11 +166,11 @@ public class JcrItemResourceFactory {
         final VersionHistory history = versionManager.getVersionHistory(node.getPath());
         if (history.hasVersionLabel(versionSpecifier)) {
             return history.getVersionByLabel(versionSpecifier).getFrozenNode();
-        } else if (history.hasNode(versionSpecifier)) {
-            return history.getVersion(versionSpecifier).getFrozenNode();
-        } else {
-            return null;
         }
+        if (history.hasNode(versionSpecifier)) {
+            return history.getVersion(versionSpecifier).getFrozenNode();
+        }
+        return null;
     }
 
     private static boolean isVersionable(Item item) throws RepositoryException {

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrNodeResource.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrNodeResource.java
@@ -106,8 +106,9 @@ class JcrNodeResource extends JcrItemResource<Node> { // this should be package 
         // Yes, this isn't how you're supposed to compare Strings, but this is intentional.
         if (resourceSuperType == UNSET_RESOURCE_SUPER_TYPE) {
             try {
-                if (getNode().hasProperty(JcrResourceConstants.SLING_RESOURCE_SUPER_TYPE_PROPERTY)) {
-                    resourceSuperType = getNode().getProperty(JcrResourceConstants.SLING_RESOURCE_SUPER_TYPE_PROPERTY).getValue().getString();
+                Property property = NodeUtil.getPropertyOrNull(getNode(), JcrResourceConstants.SLING_RESOURCE_SUPER_TYPE_PROPERTY);
+                if (property != null) {
+                    resourceSuperType = property.getValue().getString();
                 }
             } catch (RepositoryException re) {
                 // we ignore this


### PR DESCRIPTION
In OAK-9819 the JackrabbitNode interface was extended by ```getPropertyOrNull``` which can improve the performance in the common case of this pattern:

```
if (node.hasProperty(PROP)) {
  Property p = node.getProperty(PROP);
}
```

This is a pattern we have a few times in this bundle, and this code could benefit quite a lot from this improvement.

To make this work I had to update the Oak dependency to the latest release 1.44.0.

