### PR TITLE
SLING-11482 : Redundant checks for null

### DIFF
--- a/src/main/java/org/apache/sling/jcr/resource/internal/JcrValueMap.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/JcrValueMap.java
@@ -90,10 +90,6 @@ public class JcrValueMap implements ValueMap {
     @SuppressWarnings("unchecked")
     public <T> T get(final @NotNull String aKey, final @NotNull Class<T> type) {
         final String key = checkKey(aKey);
-        if (type == null) {
-            return (T) get(key);
-        }
-
         final JcrPropertyMapCacheEntry entry = this.read(key);
         if (entry == null) {
             return null;
@@ -108,9 +104,6 @@ public class JcrValueMap implements ValueMap {
     @SuppressWarnings("unchecked")
     public <T> @NotNull T get(final @NotNull String aKey, final @NotNull T defaultValue) {
         final String key = checkKey(aKey);
-        if (defaultValue == null) {
-            return (T) get(key);
-        }
 
         // special handling in case the default value implements one
         // of the interface types supported by the convertToType method

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrItemResourceFactory.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrItemResourceFactory.java
@@ -74,11 +74,6 @@ public class JcrItemResourceFactory {
      */
     public @Nullable JcrItemResource<?> createResource(final @NotNull ResourceResolver resourceResolver, final @NotNull String resourcePath,
                                                        final @Nullable Resource parent, final @Nullable Map<String, String> parameters) throws RepositoryException {
-        if (resourcePath == null) {
-            log.debug("createResource: {} maps to an empty JCR path", resourcePath);
-            return null;
-        }
-
         final String version;
         if (parameters != null && parameters.containsKey("v")) {
             version = parameters.get("v");
@@ -158,11 +153,7 @@ public class JcrItemResourceFactory {
             if (childNode != null) {
                 return childNode;
             }
-            Property property = NodeUtil.getPropertyOrNull(node, relPath);
-            if (property != null) {
-                return property;
-            }
-            return null;
+            return NodeUtil.getPropertyOrNull(node, relPath);
         } catch (RepositoryException e) {
             log.debug("getSubitem: Can't get subitem {} of {}: {}", relPath, node, e.toString());
             return null;

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProvider.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProvider.java
@@ -546,12 +546,7 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
         Item item = resource.adaptTo(Item.class);
         try {
             if (item == null) {
-                final String jcrPath = resource.getPath();
-                if (jcrPath == null) {
-                    logger.debug("delete: {} maps to an empty JCR path", resource.getPath());
-                    throw new PersistenceException("Unable to delete resource", null, resource.getPath(), null);
-                }
-                item = getSession(ctx).getItem(jcrPath);
+                item = getSession(ctx).getItem(resource.getPath());
             }
             item.remove();
         } catch (final RepositoryException e) {


### PR DESCRIPTION
hi @joerghoh , @cziegeler , please let me know if you have any concerns with the proposed fix. according to nullability annotations all those checks for a param/return value being null are redundant. 