### PR TITLE
SLING-11614 avoid duplicate creation of child node iterator

### DIFF
--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrNodeResource.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrNodeResource.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import javax.jcr.Item;
 import javax.jcr.ItemNotFoundException;
 import javax.jcr.Node;
+import javax.jcr.NodeIterator;
 import javax.jcr.Property;
 import javax.jcr.RepositoryException;
 
@@ -217,15 +218,13 @@ class JcrNodeResource extends JcrItemResource<Node> { // this should be package 
         return null;
     }
 
-
-    // ---------- Descendable interface ----------------------------------------
-
     @Override
     @Nullable Iterator<Resource> listJcrChildren() {
         try {
-            if (getNode().hasNodes()) {
+        	NodeIterator iter = getNode().getNodes();
+            if (iter.hasNext()) {
                 return new JcrNodeResourceIterator(getResourceResolver(), path, version,
-                        getNode().getNodes(), this.helper, null);
+                        iter, this.helper, null);
             }
         } catch (final RepositoryException re) {
             LOGGER.error("listChildren: Cannot get children of " + this, re);


### PR DESCRIPTION
Depending on the implementation the creation of the NodeIterator and reading the child nodes is not lazy (in Oak it is not); that means that checking for the presence of a single child node in the iterator requires to read the complete child node list, which can be slow (depending on the number of child nodes).

Also remove the reference to the non-existing "Descendable" interface