### PR TITLE
SLING-12300 - Provide a way to retrieve a JCR backed resource by its node identifier

### DIFF
--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrItemResourceFactory.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrItemResourceFactory.java
@@ -91,7 +91,7 @@ public class JcrItemResourceFactory {
         } else {
             final JcrItemResource<?> resource;
             if (item.isNode()) {
-                if (resourcePath.startsWith(SEARCH_BY_ID_PREFIX)) {
+                if (JcrResourceProvider.isIdAddressingEnabled() && resourcePath.startsWith(SEARCH_BY_ID_PREFIX)) {
                     log.debug("createResource: Found JCR Node Resource by ID at path '{}'", resourcePath);
                     resource = new JcrNodeResource(resourceResolver, item.getPath(), version, (Node) item, helper);
                 } else {
@@ -193,7 +193,7 @@ public class JcrItemResourceFactory {
         Item item = null;
         try {
             // check if the lookup is by ID
-            if (path.startsWith(SEARCH_BY_ID_PREFIX)) {
+            if (JcrResourceProvider.isIdAddressingEnabled() && path.startsWith(SEARCH_BY_ID_PREFIX)) {
                 item = session.getNodeByIdentifier(path.substring(SEARCH_BY_ID_PREFIX.length()));
             } else if (this.isJackrabbit) {
                 // Use fast getItemOrNull if session is a JackrabbitSession

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrItemResourceFactoryTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrItemResourceFactoryTest.java
@@ -18,12 +18,8 @@
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
-import org.apache.jackrabbit.JcrConstants;
-import org.apache.jackrabbit.commons.JcrUtils;
-import org.apache.jackrabbit.commons.jackrabbit.authorization.AccessControlUtils;
-import org.apache.jackrabbit.oak.commons.PathUtils;
-import org.apache.jackrabbit.oak.spi.security.principal.EveryonePrincipal;
-import org.apache.sling.jcr.resource.internal.HelperData;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.jcr.GuestCredentials;
 import javax.jcr.Item;
@@ -31,8 +27,13 @@ import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.security.Privilege;
-import java.lang.reflect.Proxy;
-import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.jackrabbit.JcrConstants;
+import org.apache.jackrabbit.commons.JcrUtils;
+import org.apache.jackrabbit.commons.jackrabbit.authorization.AccessControlUtils;
+import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.jackrabbit.oak.spi.security.principal.EveryonePrincipal;
+import org.apache.sling.jcr.resource.internal.HelperData;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -42,8 +43,10 @@ public class JcrItemResourceFactoryTest extends SlingRepositoryTestBase {
     public static final String EXISTING_NODE_PATH = "/existing";
     public static final String NON_EXISTING_NODE_PATH = "/nonexisting";
     public static final String NON_ABSOLUTE_PATH = "invalidpath";
+    public static final String REFERENCEABLE_NODE_PATH = "/referenceable";
 
     private Node node;
+    private Node referenceableNode;
     private Session nonJackrabbitSession;
 
     @Override
@@ -51,6 +54,8 @@ public class JcrItemResourceFactoryTest extends SlingRepositoryTestBase {
         super.setUp();
         final Session session = getSession();
         node = JcrUtils.getOrCreateByPath(EXISTING_NODE_PATH, "nt:unstructured", session);
+        referenceableNode = JcrUtils.getOrCreateByPath(REFERENCEABLE_NODE_PATH, "nt:unstructured", session);
+        referenceableNode.addMixin(JcrConstants.MIX_REFERENCEABLE);
         session.save();
 
         nonJackrabbitSession = (Session) Proxy.newProxyInstance(
@@ -137,6 +142,24 @@ public class JcrItemResourceFactoryTest extends SlingRepositoryTestBase {
         when(s.getItem(EXISTING_NODE_PATH)).thenReturn(nonJackrabbitSession.getItem(EXISTING_NODE_PATH));
         when(s.nodeExists(PathUtils.getParentPath(EXISTING_NODE_PATH))).thenThrow(new RepositoryException());
         compareGetParentOrNull(s, EXISTING_NODE_PATH, true);
+    }
+
+    public void testGetNodeByIdentifier() throws RepositoryException {
+        HelperData helper = new HelperData(new AtomicReference<>(), new AtomicReference<>());
+        String identifier = referenceableNode.getIdentifier();
+        String uuid = referenceableNode.getProperty(JcrConstants.JCR_UUID).getString();
+        assertEquals(identifier, uuid);
+        Item referenceableItem =
+                new JcrItemResourceFactory(session, helper).getItemOrNull(JcrItemResourceFactory.SEARCH_BY_ID_PREFIX + referenceableNode.getIdentifier());
+        assertNotNull(referenceableItem);
+        assertTrue(referenceableItem.isNode());
+        assertEquals(REFERENCEABLE_NODE_PATH, referenceableItem.getPath());
+
+        // the node identifier in this case is the path
+        Item nodeItem = new JcrItemResourceFactory(session, helper).getItemOrNull(JcrItemResourceFactory.SEARCH_BY_ID_PREFIX + node.getIdentifier());
+        assertNotNull(nodeItem);
+        assertTrue(nodeItem.isNode());
+        assertEquals(EXISTING_NODE_PATH, nodeItem.getPath());
     }
 
     private void compareGetParentOrNull(Session s, String path, boolean nullExpected) throws RepositoryException {

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProviderSessionHandlingTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProviderSessionHandlingTest.java
@@ -18,18 +18,6 @@
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeThat;
-import static org.junit.Assume.assumeTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -58,6 +46,18 @@ import org.mockito.Mockito;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.ComponentContext;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeThat;
+import static org.junit.Assume.assumeTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(Parameterized.class)
 public class JcrResourceProviderSessionHandlingTest {
@@ -227,8 +227,10 @@ public class JcrResourceProviderSessionHandlingTest {
         ComponentContext ctx = mock(ComponentContext.class);
         when(ctx.locateService(ArgumentMatchers.anyString(), Mockito.any())).thenReturn(repo);
 
+        JcrResourceProvider.Configuration configuration = mock(JcrResourceProvider.Configuration.class);
+
         jcrResourceProvider = new JcrResourceProvider();
-        jcrResourceProvider.activate(ctx);
+        jcrResourceProvider.activate(ctx, configuration);
 
         jcrProviderState = jcrResourceProvider.authenticate(authInfo);
     }

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProviderTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProviderTest.java
@@ -18,10 +18,6 @@
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
-import static javax.jcr.nodetype.NodeType.NT_UNSTRUCTURED;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.security.Principal;
 import java.util.HashMap;
 import java.util.Map;
@@ -32,6 +28,7 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
 import org.apache.jackrabbit.JcrConstants;
+import org.apache.jackrabbit.commons.JcrUtils;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
@@ -47,6 +44,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.osgi.service.component.ComponentContext;
+
+import static javax.jcr.nodetype.NodeType.NT_UNSTRUCTURED;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JcrResourceProviderTest extends SlingRepositoryTestBase {
@@ -212,6 +213,25 @@ public class JcrResourceProviderTest extends SlingRepositoryTestBase {
         assertEquals("/childnode/grandchild", grandchild.getPath());
         assertEquals("admin",grandchild.getItem().getProperty("jcr:createdBy").getString());
         
+    }
+
+    @Test
+    public void getResourceByIdentifier() throws RepositoryException {
+        Node referenceable = JcrUtils.getOrCreateByPath("/root/referenceable", JcrConstants.NT_UNSTRUCTURED, session);
+        referenceable.addMixin(JcrConstants.MIX_REFERENCEABLE);
+        Node nonReferenceable = JcrUtils.getOrCreateByPath("/root/non-referenceable", JcrConstants.NT_UNSTRUCTURED,
+                session);
+        session.save();
+
+        Resource referenceableResource = jcrResourceProvider.getResource(mockResolveContext(),
+                JcrItemResourceFactory.SEARCH_BY_ID_PREFIX + referenceable.getIdentifier(), ResourceContext.EMPTY_CONTEXT, null);
+        assertNotNull(referenceableResource);
+        assertEquals(referenceableResource.getPath(), referenceable.getPath());
+
+        Resource nonReferenceableResource = jcrResourceProvider.getResource(mockResolveContext(),
+                JcrItemResourceFactory.SEARCH_BY_ID_PREFIX + nonReferenceable.getIdentifier(), ResourceContext.EMPTY_CONTEXT, null);
+        assertNotNull(nonReferenceableResource);
+        assertEquals(nonReferenceableResource.getPath(), nonReferenceable.getPath());
     }
     
 

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProviderTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProviderTest.java
@@ -32,6 +32,7 @@ import org.apache.jackrabbit.commons.JcrUtils;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 import org.apache.sling.jcr.resource.internal.HelperData;
 import org.apache.sling.spi.resource.provider.ResolveContext;
@@ -42,6 +43,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.osgi.service.component.ComponentContext;
 
@@ -54,6 +57,7 @@ public class JcrResourceProviderTest extends SlingRepositoryTestBase {
 
     JcrResourceProvider jcrResourceProvider;
     Session session;
+    ComponentContext ctx;
 
     @Override
     @Before
@@ -61,9 +65,11 @@ public class JcrResourceProviderTest extends SlingRepositoryTestBase {
         super.setUp();
         // create the session
         session = getSession();
-        ComponentContext ctx = mock(ComponentContext.class);
+        ctx = mock(ComponentContext.class);
+        when(ctx.locateService(ArgumentMatchers.anyString(), Mockito.any())).thenReturn(SlingRepositoryProvider.getRepository());
+        JcrResourceProvider.Configuration configuration = mock(JcrResourceProvider.Configuration.class);
         jcrResourceProvider = new JcrResourceProvider();
-        jcrResourceProvider.activate(ctx);
+        jcrResourceProvider.activate(ctx, configuration);
     }
 
     @Override
@@ -87,6 +93,7 @@ public class JcrResourceProviderTest extends SlingRepositoryTestBase {
     private @NotNull ResolveContext mockResolveContext() {
         ResolveContext ctx = mock(ResolveContext.class);
         when(ctx.getProviderState()).thenReturn(createProviderState());
+        when(ctx.getResourceResolver()).thenReturn(mock(ResourceResolver.class));
         return ctx;
     }
 
@@ -216,7 +223,11 @@ public class JcrResourceProviderTest extends SlingRepositoryTestBase {
     }
 
     @Test
-    public void getResourceByIdentifier() throws RepositoryException {
+    public void getResourceByIdentifierConfigurationEnabled() throws RepositoryException {
+        JcrResourceProvider.Configuration configuration = mock(JcrResourceProvider.Configuration.class);
+        when(configuration.resource_addressingById()).thenReturn(true);
+        jcrResourceProvider.activate(ctx, configuration);
+
         Node referenceable = JcrUtils.getOrCreateByPath("/root/referenceable", JcrConstants.NT_UNSTRUCTURED, session);
         referenceable.addMixin(JcrConstants.MIX_REFERENCEABLE);
         Node nonReferenceable = JcrUtils.getOrCreateByPath("/root/non-referenceable", JcrConstants.NT_UNSTRUCTURED,
@@ -232,6 +243,23 @@ public class JcrResourceProviderTest extends SlingRepositoryTestBase {
                 JcrItemResourceFactory.SEARCH_BY_ID_PREFIX + nonReferenceable.getIdentifier(), ResourceContext.EMPTY_CONTEXT, null);
         assertNotNull(nonReferenceableResource);
         assertEquals(nonReferenceableResource.getPath(), nonReferenceable.getPath());
+    }
+
+    @Test
+    public void getResourceByIdentifierConfigurationNotEnabled() throws RepositoryException {
+        Node referenceable = JcrUtils.getOrCreateByPath("/root/referenceable", JcrConstants.NT_UNSTRUCTURED, session);
+        referenceable.addMixin(JcrConstants.MIX_REFERENCEABLE);
+        Node nonReferenceable = JcrUtils.getOrCreateByPath("/root/non-referenceable", JcrConstants.NT_UNSTRUCTURED,
+                session);
+        session.save();
+
+        Resource referenceableResource = jcrResourceProvider.getResource(mockResolveContext(),
+                JcrItemResourceFactory.SEARCH_BY_ID_PREFIX + referenceable.getIdentifier(), ResourceContext.EMPTY_CONTEXT, null);
+        assertNull(referenceableResource);
+
+        Resource nonReferenceableResource = jcrResourceProvider.getResource(mockResolveContext(),
+                JcrItemResourceFactory.SEARCH_BY_ID_PREFIX + nonReferenceable.getIdentifier(), ResourceContext.EMPTY_CONTEXT, null);
+        assertNull(nonReferenceableResource);
     }
     
 


### PR DESCRIPTION
* added support for a /jcr:id/ prefix to the JcrItemResourceFactory when retrieving items by path
* made sure to return the JCR path no matter which retrieval mode was performed