### PR TITLE
SLING-12320 - Add support for retrieving a service resource resolver with impersonation without requiring extra configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.jcr.api</artifactId>
-            <version>2.2.0</version>
+            <version>2.3.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrProviderStateFactory.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrProviderStateFactory.java
@@ -18,8 +18,6 @@
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
-import static org.apache.sling.api.resource.ResourceResolverFactory.NEW_PASSWORD;
-
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -44,6 +42,8 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.sling.api.resource.ResourceResolverFactory.NEW_PASSWORD;
 
 public class JcrProviderStateFactory {
 
@@ -111,7 +111,20 @@ public class JcrProviderStateFactory {
                     } else {
                         final Object subService = authenticationInfo.get(ResourceResolverFactory.SUBSERVICE);
                         final String subServiceName = subService instanceof String ? (String) subService : null;
-                        session = repo.loginService(subServiceName, null);
+                        // let's shortcut the impersonation for service users, if impersonation was requested
+                        String sudoUser = getSudoUser(authenticationInfo);
+                        if (sudoUser != null) {
+                            SimpleCredentials creds = new SimpleCredentials(sudoUser, new char[0]);
+                            creds.setAttribute(ResourceResolver.USER_IMPERSONATOR, subServiceName == null ?
+                                    bundle.getSymbolicName() : subServiceName);
+                            session = repo.impersonateFromService(subServiceName, creds, null);
+                            // if the impersonation worked we should have a session now; let's remove the sudo user
+                            // from the authentication info to skip the impersonation logic below
+                            authenticationInfo.remove(ResourceResolverFactory.USER_IMPERSONATION);
+                        } else {
+                            session = repo.loginService(subServiceName, null);
+
+                        }
                     }
                 } catch (Throwable t) {
                     // unget the repository if the service cannot

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrProviderStateFactory.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrProviderStateFactory.java
@@ -111,10 +111,15 @@ public class JcrProviderStateFactory {
                     } else {
                         final Object subService = authenticationInfo.get(ResourceResolverFactory.SUBSERVICE);
                         final String subServiceName = subService instanceof String ? (String) subService : null;
-                        // let's shortcut the impersonation for service users, if impersonation was requested
+                        // let's shortcut the impersonation for services, if impersonation was requested
                         String sudoUser = getSudoUser(authenticationInfo);
                         if (sudoUser != null) {
                             SimpleCredentials creds = new SimpleCredentials(sudoUser, new char[0]);
+
+                            // while this attribute is not used by the JCR API, it is expected that the
+                            // ResourceResolver provides it when a session was impersonated; in the actual
+                            // implementation it will be retrieved from the session when calling {@link
+                            // ResourceResolver#getAttribute(String)} with {@link ResourceResolver#USER_IMPERSONATOR}
                             creds.setAttribute(ResourceResolver.USER_IMPERSONATOR, subServiceName == null ?
                                     bundle.getSymbolicName() : subServiceName);
                             session = repo.impersonateFromService(subServiceName, creds, null);

--- a/src/test/java/org/apache/sling/jcr/resource/internal/JcrResourceListenerTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/JcrResourceListenerTest.java
@@ -16,13 +16,6 @@
  */
 package org.apache.sling.jcr.resource.internal;
 
-import static java.util.Collections.synchronizedList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -32,6 +25,7 @@ import java.util.Set;
 
 import javax.jcr.AccessDeniedException;
 import javax.jcr.Credentials;
+import javax.jcr.LoginException;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
@@ -53,6 +47,13 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import static java.util.Collections.synchronizedList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Test of JcrResourceListener.
@@ -155,6 +156,11 @@ public class JcrResourceListenerTest {
                     @Override
                     public String getDefaultWorkspace() {
                         return repository.getDefaultWorkspace();
+                    }
+
+                    @Override
+                    public Session impersonateFromService(String s, Credentials credentials, String s1) throws LoginException, RepositoryException {
+                        return loginAdministrative(s1).impersonate(credentials);
                     }
                 });
         this.listener = new JcrResourceListener(this.config,

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProviderSessionHandlingTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProviderSessionHandlingTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 import javax.jcr.Credentials;
+import javax.jcr.LoginException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.Value;
@@ -188,6 +189,10 @@ public class JcrResourceProviderSessionHandlingTest {
             return wrapped.loginAdministrative(workspace);
         }
 
+        @Override
+        public Session impersonateFromService(String s, Credentials credentials, String s1) throws LoginException, RepositoryException {
+            return loginAdministrative(s1).impersonate(credentials);
+        }
     }
 
     @Before
@@ -292,8 +297,11 @@ public class JcrResourceProviderSessionHandlingTest {
         ResolveContext<JcrProviderState> mockContext = mock(ResolveContext.class);
         when(mockContext.getProviderState()).thenReturn(jcrProviderState);
         Object reportedImpersonator = jcrResourceProvider.getAttribute(mockContext, ResourceResolver.USER_IMPERSONATOR);
-
-        assertEquals(AUTH_USER, reportedImpersonator);
+        if (loginStyle == LoginStyle.SERVICE) {
+            assertEquals("dummy-service", reportedImpersonator);
+        } else {
+            assertEquals(AUTH_USER, reportedImpersonator);
+        }
     }
 
     @Test


### PR DESCRIPTION
* for services that want to impersonate, simply call SlingRepository#impersonateFromService