### PR TITLE
SLING-12742 Don't swallow IOException during serialization

### DIFF
--- a/src/main/java/org/apache/sling/jcr/resource/internal/JcrModifiableValueMap.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/JcrModifiableValueMap.java
@@ -73,7 +73,7 @@ public class JcrModifiableValueMap extends JcrValueMap implements ModifiableValu
                 node.setProperty(name, entry.convertToType(Value.class, node, this.helper.getDynamicClassLoader()));
             }
         } catch (final RepositoryException re) {
-            throw new IllegalArgumentException("Value '" + value + "' for property '" + key + "' can't be put into node '" + getPath() + "'.", re);
+            throw new IllegalArgumentException("Value of class '" + value.getClass() + "' for property '" + key + "' can't be put into node '" + getPath() + "'.", re);
         }
         this.valueCache.put(key, value);
 

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/JcrPropertyMapCacheEntry.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/JcrPropertyMapCacheEntry.java
@@ -106,7 +106,7 @@ public class JcrPropertyMapCacheEntry {
         }
         final Value val = createValue(value, node);
         if (val == null) {
-            throw new IllegalArgumentException("Value can't be stored in the repository: " + value);
+            throw new IllegalArgumentException("Value can't be stored in the repository as it is having an unsupported type " + value.getClass());
         }
     }
 
@@ -132,7 +132,7 @@ public class JcrPropertyMapCacheEntry {
                 final ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
                 value = session.getValueFactory().createValue(session.getValueFactory().createBinary(bais));
             } catch (IOException ioe) {
-                // we ignore this here and return null
+                throw new RepositoryException("Cannot serialize object", ioe);
             }
         }
         return value;

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/JcrPropertyMapCacheEntryTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/JcrPropertyMapCacheEntryTest.java
@@ -18,30 +18,6 @@
  */
 package org.apache.sling.jcr.resource.internal.helper;
 
-import com.google.common.collect.Maps;
-import org.apache.jackrabbit.value.BooleanValue;
-import org.apache.jackrabbit.value.ValueFactoryImpl;
-import org.junit.Before;
-import org.junit.Test;
-
-import javax.jcr.Node;
-import javax.jcr.Property;
-import javax.jcr.PropertyType;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import javax.jcr.Value;
-import javax.jcr.ValueFactory;
-import javax.jcr.ValueFormatException;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.util.Calendar;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -53,6 +29,34 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.PropertyType;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Value;
+import javax.jcr.ValueFactory;
+import javax.jcr.ValueFormatException;
+
+import org.apache.jackrabbit.value.BooleanValue;
+import org.apache.jackrabbit.value.ValueFactoryImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.Maps;
 
 /**
  * Testcase for {@link JcrPropertyMapCacheEntry}
@@ -444,10 +448,25 @@ public class JcrPropertyMapCacheEntryTest {
     }
     
     @Test(expected = IllegalArgumentException.class)
-    public void testCreateFromUnstorableValue() throws Exception {
+    public void testCreateFromNonSerializableComplexValue() throws Exception {
         Object value = new TestClass();
         new JcrPropertyMapCacheEntry(value, node);
     }
     
     private static final class TestClass {}
+    
+    @Test(expected = RepositoryException.class)
+    public void testCreateFromSerializeComplexValueWithUnserializableField() throws Exception {
+        // this class cannot be serialized and throws an exception at runtime (as Optional is not serializable)
+        Object value = new TestClass2();
+        new JcrPropertyMapCacheEntry(value, node);
+    }
+    
+    private static final class TestClass2 implements Serializable {
+        Optional<String> value;
+        
+        public TestClass2() {
+            this.value = Optional.empty();
+        }
+    }
 }


### PR DESCRIPTION
Improve exception messages when trying to put incompatible types into ModifiableValueMaps