### PR TITLE
SLING-12944 Retrieve primary type as fallback via

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>2.2</version>
+            <version>3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/apache/sling/jcr/resource/internal/JcrValueMapTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/JcrValueMapTest.java
@@ -18,9 +18,16 @@
  */
 package org.apache.sling.jcr.resource.internal;
 
+import static org.mockito.Mockito.times;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.AbstractMap.SimpleEntry;
+
 import javax.jcr.Node;
+import javax.jcr.RepositoryException;
 
 import org.apache.sling.jcr.resource.internal.helper.jcr.SlingRepositoryTestBase;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -58,6 +65,24 @@ public class JcrValueMapTest extends SlingRepositoryTestBase {
         assertEquals("test", vm.get("string",null)); 
     }
     
-   
+    /**
+     * Make sure cache is fully populated even
+     * @throws RepositoryException 
+     */
+    @Test
+    public void testGetEntrySet() throws RepositoryException {
+        Node node = Mockito.spy(rootNode);
+        JcrValueMap vm = new JcrValueMap(node, helperData);
+        assertThat( vm.entrySet(), Matchers.hasSize(3) );
+        assertThat( vm.keySet(), Matchers.hasSize(3) );
+        assertThat( vm.values(), Matchers.hasSize(3) );
+        assertThat( vm.entrySet(), Matchers.containsInAnyOrder(
+                new SimpleEntry<String, Object>("jcr:primaryType", "nt:unstructured"),
+                new SimpleEntry<String, Object>("sling:resourceType", "nt:unstructured"),
+                new SimpleEntry<String, Object>("string", "test")
+                ));
+        // cache should only be populated once
+        Mockito.verify(node, times(1)).getProperties();
+    }
 
 }

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrNodeResourceTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrNodeResourceTest.java
@@ -34,6 +34,7 @@ import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceMetadata;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 
@@ -220,6 +221,7 @@ public class JcrNodeResourceTest extends JcrItemResourceTestBase {
         existingKeys.add(JcrConstants.JCR_ENCODING);
         existingKeys.add(JcrConstants.JCR_DATA);
         existingKeys.add(JcrConstants.JCR_PRIMARYTYPE);
+        existingKeys.add(ResourceResolver.PROPERTY_RESOURCE_TYPE);
         final Set<Object> crossCheck = new HashSet<>(props.keySet());
         crossCheck.removeAll(existingKeys);
         assertTrue(crossCheck.isEmpty());


### PR DESCRIPTION
Node.getPrimaryNodeType()

The permission evaluation is skipped for this call. Also make sure to populate the cache with entries for both "sling:resourceType" and "jcr:primaryType" with readFully()