### PR TITLE
chore(build): bump sling-bundle-parent to v66 and set Java 8 target

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>52</version>
+        <version>66</version>
         <relativePath />
     </parent>
 
@@ -42,6 +42,8 @@
   </scm>
 
     <properties>
+        <sling.java.version>8</sling.java.version>
+        <spotless.check.skip>true</spotless.check.skip>
         <site.jira.version.id>12314286</site.jira.version.id>
         <site.javadoc.exclude>**.internal.**</site.javadoc.exclude>
         <!-- oak 1.44.0 first version to include JackrabbitNode.getPropertyOrNull in oak-jackrabbit-api (https://issues.apache.org/jira/browse/SLING-11449) -->
@@ -272,5 +274,3 @@
         </dependency>
     </dependencies>
 </project>
-
-


### PR DESCRIPTION
Updates the Maven POM to use a newer parent POM version and align build properties.

- Bump `sling-bundle-parent` version from `52` to `66`
- Add `sling.java.version` property set to `8`
- Add `spotless.check.skip=true` to disable Spotless checks
- Remove trailing blank lines at end of file

Co-authored-by: Maia <maia@noreply>