### PR TITLE
chore: upgrade parent POM to v66 and reformat Java sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>52</version>
+        <version>66</version>
         <relativePath />
     </parent>
 
@@ -30,64 +30,42 @@
     <version>3.3.7-SNAPSHOT</version>
 
     <name>Apache Sling JCR Resource</name>
-    <description>
-        This bundle provides the JCR based ResourceProvider.
-    </description>
+    <description>This bundle provides the JCR based ResourceProvider.</description>
 
     <scm>
         <connection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-jcr-resource.git</connection>
         <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-jcr-resource.git</developerConnection>
+        <tag>HEAD</tag>
         <url>https://github.com/apache/sling-org-apache-sling-jcr-resource.git</url>
-      <tag>HEAD</tag>
-  </scm>
+    </scm>
 
     <properties>
+        <sling.java.version>8</sling.java.version>
         <site.jira.version.id>12314286</site.jira.version.id>
         <site.javadoc.exclude>**.internal.**</site.javadoc.exclude>
         <!-- oak 1.44.0 first version to include JackrabbitNode.getPropertyOrNull in oak-jackrabbit-api (https://issues.apache.org/jira/browse/SLING-11449) -->
         <oak.version>1.44.0</oak.version>
-        <jackrabbit.version>2.18.0</jackrabbit.version><!-- required for direct binary access, https://issues.apache.org/jira/browse/JCR-4335 -->
+        <jackrabbit.version>2.18.0</jackrabbit.version>
+        <!-- required for direct binary access, https://issues.apache.org/jira/browse/JCR-4335 -->
         <project.build.outputTimestamp>1758870262</project.build.outputTimestamp>
     </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.sling</groupId>
-                <artifactId>sling-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>generate-adapter-metadata</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>generate-adapter-metadata</goal>
-                        </goals>
-                        <configuration>
-                            <!-- relying on https://issues.apache.org/jira/browse/MNG-5001 until https://issues.apache.org/jira/browse/SLING-10022 -->
-                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-    
     <dependencies>
-    <!-- Logging -->
+        <!-- Logging -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>
         </dependency>
 
-    <!-- JCR -->
+        <!-- JCR -->
         <dependency>
             <groupId>javax.jcr</groupId>
             <artifactId>jcr</artifactId>
             <scope>provided</scope>
         </dependency>
 
-    <!-- OSGi -->
+        <!-- OSGi -->
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.framework</artifactId>
@@ -113,7 +91,7 @@
             <artifactId>org.osgi.service.component</artifactId>
             <scope>provided</scope>
         </dependency>
-    <!-- Jackrabbit / Oak -->
+        <!-- Jackrabbit / Oak -->
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>oak-jackrabbit-api</artifactId>
@@ -140,7 +118,7 @@
             <scope>provided</scope>
         </dependency>
 
-    <!-- Sling -->
+        <!-- Sling -->
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.jcr.api</artifactId>
@@ -271,6 +249,26 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>sling-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-adapter-metadata</id>
+                        <goals>
+                            <goal>generate-adapter-metadata</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                        <configuration>
+                            <!-- relying on https://issues.apache.org/jira/browse/MNG-5001 until https://issues.apache.org/jira/browse/SLING-10022 -->
+                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>
-
-

--- a/src/main/java/org/apache/sling/jcr/resource/api/JcrResourceChange.java
+++ b/src/main/java/org/apache/sling/jcr/resource/api/JcrResourceChange.java
@@ -28,10 +28,12 @@ public final class JcrResourceChange extends ResourceChange {
     private final String userId;
     private final String userData;
 
-    public JcrResourceChange(final ResourceChange.ChangeType changeType,
-                             final String path,
-                             final boolean isExternal,
-                             final String userId, String userData) {
+    public JcrResourceChange(
+            final ResourceChange.ChangeType changeType,
+            final String path,
+            final boolean isExternal,
+            final String userId,
+            String userData) {
         super(changeType, path, isExternal);
         this.userId = userId;
         this.userData = userData;

--- a/src/main/java/org/apache/sling/jcr/resource/api/JcrResourceConstants.java
+++ b/src/main/java/org/apache/sling/jcr/resource/api/JcrResourceConstants.java
@@ -33,8 +33,7 @@ public class JcrResourceConstants {
      * session used by the JCR Resource bundle through the
      * <code>Sling-Namespaces</code> bundle manifest header.
      */
-    public static final String SLING_NAMESPACE_URI = SlingConstants.NAMESPACE_URI_ROOT
-        + "jcr/sling/1.0";
+    public static final String SLING_NAMESPACE_URI = SlingConstants.NAMESPACE_URI_ROOT + "jcr/sling/1.0";
 
     /**
      * The name of the JCR Property that defines the resource type of this node

--- a/src/main/java/org/apache/sling/jcr/resource/api/package-info.java
+++ b/src/main/java/org/apache/sling/jcr/resource/api/package-info.java
@@ -19,5 +19,3 @@
 
 @org.osgi.annotation.versioning.Version("1.1.0")
 package org.apache.sling.jcr.resource.api;
-
-

--- a/src/main/java/org/apache/sling/jcr/resource/internal/HelperData.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/HelperData.java
@@ -18,10 +18,10 @@
  */
 package org.apache.sling.jcr.resource.internal;
 
-import java.util.concurrent.atomic.AtomicReference;
-
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.sling.api.resource.external.URIProvider;
 import org.apache.sling.commons.classloader.DynamicClassLoaderManager;
@@ -41,8 +41,9 @@ public class HelperData {
 
     private volatile String[] namespacePrefixes;
 
-    public HelperData(final @NotNull AtomicReference<DynamicClassLoaderManager> dynamicClassLoaderManagerReference,
-                      @NotNull AtomicReference<URIProvider[]> uriProviderReference) {
+    public HelperData(
+            final @NotNull AtomicReference<DynamicClassLoaderManager> dynamicClassLoaderManagerReference,
+            @NotNull AtomicReference<URIProvider[]> uriProviderReference) {
         this.dynamicClassLoaderManagerReference = dynamicClassLoaderManagerReference;
         this.uriProviderReference = uriProviderReference;
     }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/JcrListenerBaseConfig.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/JcrListenerBaseConfig.java
@@ -18,16 +18,16 @@
  */
 package org.apache.sling.jcr.resource.internal;
 
-import java.io.Closeable;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.observation.Event;
 import javax.jcr.observation.EventListener;
 import javax.jcr.observation.ObservationManager;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 import org.apache.jackrabbit.api.observation.JackrabbitEventFilter;
 import org.apache.jackrabbit.api.observation.JackrabbitObservationManager;
@@ -55,7 +55,8 @@ public class JcrListenerBaseConfig implements Closeable {
     private final ObservationReporter reporter;
 
     @SuppressWarnings("deprecation")
-    public JcrListenerBaseConfig(final @NotNull ObservationReporter reporter, final @NotNull SlingRepository repository) throws RepositoryException {
+    public JcrListenerBaseConfig(final @NotNull ObservationReporter reporter, final @NotNull SlingRepository repository)
+            throws RepositoryException {
         this.reporter = reporter;
         // The session should have read access on the whole repository
         this.session = repository.loginService("observation", repository.getDefaultWorkspace());
@@ -76,7 +77,8 @@ public class JcrListenerBaseConfig implements Closeable {
      * @param config The configuration
      * @throws RepositoryException If registration fails.
      */
-    public void register(final @NotNull EventListener listener, final @NotNull ObserverConfiguration config) throws RepositoryException {
+    public void register(final @NotNull EventListener listener, final @NotNull ObserverConfiguration config)
+            throws RepositoryException {
         final ObservationManager mgr = this.session.getWorkspace().getObservationManager();
         if (mgr instanceof JackrabbitObservationManager) {
             final OakEventFilter filter = FilterFactory.wrap(new JackrabbitEventFilter());
@@ -98,7 +100,7 @@ public class JcrListenerBaseConfig implements Closeable {
             filter.setEventTypes(getTypes(config));
 
             // nt:file handling
-            filter.withNodeTypeAggregate(new String[]{"nt:file"}, new String[]{"", "jcr:content"});
+            filter.withNodeTypeAggregate(new String[] {"nt:file"}, new String[] {"", "jcr:content"});
 
             // ancestors remove
             filter.withIncludeAncestorsRemove();
@@ -107,9 +109,8 @@ public class JcrListenerBaseConfig implements Closeable {
         } else {
             throw new RepositoryException("Observation manager is not a JackrabbitObservationManager");
         }
-
     }
-    
+
     protected static void setFilterPaths(@NotNull OakEventFilter filter, @NotNull ObserverConfiguration config) {
         final Set<String> paths = config.getPaths().toStringSet();
         // avoid any resizing of these lists

--- a/src/main/java/org/apache/sling/jcr/resource/internal/JcrModifiableValueMap.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/JcrModifiableValueMap.java
@@ -18,14 +18,14 @@
  */
 package org.apache.sling.jcr.resource.internal;
 
-import java.io.IOException;
-import java.util.Iterator;
-import java.util.Map;
-
 import javax.jcr.Node;
 import javax.jcr.Property;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
 
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.resource.ModifiableValueMap;
@@ -65,7 +65,8 @@ public class JcrModifiableValueMap extends JcrValueMap implements ModifiableValu
             this.cache.put(key, entry);
             final String name = escapeKeyName(key);
             if (JcrConstants.JCR_MIXINTYPES.equals(name)) {
-                NodeUtil.handleMixinTypes(node, entry.convertToType(String[].class, node, this.helper.getDynamicClassLoader()));
+                NodeUtil.handleMixinTypes(
+                        node, entry.convertToType(String[].class, node, this.helper.getDynamicClassLoader()));
             } else if ("jcr:primaryType".equals(name)) {
                 node.setPrimaryType(entry.convertToType(String.class, node, this.helper.getDynamicClassLoader()));
             } else if (entry.isArray()) {
@@ -74,7 +75,10 @@ public class JcrModifiableValueMap extends JcrValueMap implements ModifiableValu
                 node.setProperty(name, entry.convertToType(Value.class, node, this.helper.getDynamicClassLoader()));
             }
         } catch (final IOException | RepositoryException re) {
-            throw new IllegalArgumentException("Value of class '" + value.getClass() + "' for property '" + key + "' can't be put into node '" + getPath() + "'.", re);
+            throw new IllegalArgumentException(
+                    "Value of class '" + value.getClass() + "' for property '" + key + "' can't be put into node '"
+                            + getPath() + "'.",
+                    re);
         }
         this.valueCache.put(key, value);
 
@@ -89,7 +93,9 @@ public class JcrModifiableValueMap extends JcrValueMap implements ModifiableValu
         if (t != null) {
             final Iterator<?> i = t.entrySet().iterator();
             while (i.hasNext()) {
-                @SuppressWarnings("unchecked") final Map.Entry<? extends String, ? extends Object> entry = (Map.Entry<? extends String, ? extends Object>) i.next();
+                @SuppressWarnings("unchecked")
+                final Map.Entry<? extends String, ? extends Object> entry =
+                        (Map.Entry<? extends String, ? extends Object>) i.next();
                 put(entry.getKey(), entry.getValue());
             }
         }
@@ -111,7 +117,8 @@ public class JcrModifiableValueMap extends JcrValueMap implements ModifiableValu
                 property.remove();
             }
         } catch (final RepositoryException re) {
-            throw new IllegalArgumentException("Property '" + key + "' can't be removed from node '" + getPath() + "'.", re);
+            throw new IllegalArgumentException(
+                    "Property '" + key + "' can't be removed from node '" + getPath() + "'.", re);
         }
 
         return oldValue;

--- a/src/main/java/org/apache/sling/jcr/resource/internal/JcrResourceListener.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/JcrResourceListener.java
@@ -18,22 +18,16 @@
  */
 package org.apache.sling.jcr.resource.internal;
 
-import static javax.jcr.observation.Event.NODE_ADDED;
-import static javax.jcr.observation.Event.NODE_REMOVED;
-import static javax.jcr.observation.Event.PROPERTY_ADDED;
-import static javax.jcr.observation.Event.PROPERTY_CHANGED;
-import static javax.jcr.observation.Event.PROPERTY_REMOVED;
+import javax.jcr.RepositoryException;
+import javax.jcr.observation.Event;
+import javax.jcr.observation.EventIterator;
+import javax.jcr.observation.EventListener;
 
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import javax.jcr.RepositoryException;
-import javax.jcr.observation.Event;
-import javax.jcr.observation.EventIterator;
-import javax.jcr.observation.EventListener;
 
 import org.apache.jackrabbit.api.observation.JackrabbitEvent;
 import org.apache.sling.api.resource.observation.ResourceChange;
@@ -43,6 +37,12 @@ import org.apache.sling.spi.resource.provider.ObservationReporter;
 import org.apache.sling.spi.resource.provider.ObserverConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static javax.jcr.observation.Event.NODE_ADDED;
+import static javax.jcr.observation.Event.NODE_REMOVED;
+import static javax.jcr.observation.Event.PROPERTY_ADDED;
+import static javax.jcr.observation.Event.PROPERTY_CHANGED;
+import static javax.jcr.observation.Event.PROPERTY_REMOVED;
 
 /**
  * The <code>JcrResourceListener</code> listens for JCR observation
@@ -57,8 +57,8 @@ public class JcrResourceListener implements EventListener, Closeable {
 
     private static final Logger logger = LoggerFactory.getLogger(JcrResourceListener.class);
 
-    public JcrResourceListener(final JcrListenerBaseConfig listenerConfig,
-                               final ObserverConfiguration config) throws RepositoryException {
+    public JcrResourceListener(final JcrListenerBaseConfig listenerConfig, final ObserverConfiguration config)
+            throws RepositoryException {
         this.baseConfig = listenerConfig;
         this.config = config;
         this.baseConfig.register(this, config);
@@ -123,9 +123,7 @@ public class JcrResourceListener implements EventListener, Closeable {
                 // add is stronger than update
                 changedEvents.remove(rsrcPath);
                 addedEvents.put(rsrcPath, createResourceChange(event, rsrcPath, ChangeType.ADDED));
-            } else if (type == PROPERTY_ADDED
-                    || type == PROPERTY_REMOVED
-                    || type == PROPERTY_CHANGED) {
+            } else if (type == PROPERTY_ADDED || type == PROPERTY_REMOVED || type == PROPERTY_CHANGED) {
                 final String rsrcPath;
                 if (identifier == null || !identifier.startsWith("/")) {
                     final int lastSlash = eventPath.lastIndexOf('/');
@@ -156,17 +154,15 @@ public class JcrResourceListener implements EventListener, Closeable {
         changes.addAll(removedEvents.values());
         changes.addAll(changedEvents.values());
         this.baseConfig.getReporter().reportChanges(this.config, changes, false);
-
     }
 
-    private static ResourceChange createResourceChange(final Event event,
-                                                       final String path,
-                                                       final ChangeType changeType) {
+    private static ResourceChange createResourceChange(
+            final Event event, final String path, final ChangeType changeType) {
         final boolean isExternal = isExternal(event);
         String userId = null;
         String userData = null;
         if (!isExternal) {
-            // In Jackrabbit Oak userId and userData are not available if the event 
+            // In Jackrabbit Oak userId and userData are not available if the event
             // is external
             userId = event.getUserID();
             try {

--- a/src/main/java/org/apache/sling/jcr/resource/internal/JcrSystemUserValidator.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/JcrSystemUserValidator.java
@@ -1,28 +1,30 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.sling.jcr.resource.internal;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 
 import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
-
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 
 import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.user.Authorizable;
@@ -51,21 +53,23 @@ import org.slf4j.LoggerFactory;
  * @see org.apache.jackrabbit.api.security.user.User#isSystemUser()
  */
 @Designate(ocd = JcrSystemUserValidator.Config.class)
-@Component(service = {ServiceUserValidator.class, ServicePrincipalsValidator.class},
-           property = {
-                   Constants.SERVICE_VENDOR + "=The Apache Software Foundation"
-           })
+@Component(
+        service = {ServiceUserValidator.class, ServicePrincipalsValidator.class},
+        property = {Constants.SERVICE_VENDOR + "=The Apache Software Foundation"})
 public class JcrSystemUserValidator implements ServiceUserValidator, ServicePrincipalsValidator {
 
     public static final String VALIDATION_SERVICE_USER = "validation";
 
     @ObjectClassDefinition(
             name = "Apache Sling JCR System User Validator",
-            description = "Enforces the usage of JCR system users for all user mappings being used in the 'Sling Service User Mapper Service'")
+            description =
+                    "Enforces the usage of JCR system users for all user mappings being used in the 'Sling Service User Mapper Service'")
     public @interface Config {
 
-        @AttributeDefinition(name = "Allow only JCR System Users",
-                description="If set to true, only user IDs bound to JCR system users are allowed in the user mappings of the 'Sling Service User Mapper Service'. Otherwise all users are allowed!")
+        @AttributeDefinition(
+                name = "Allow only JCR System Users",
+                description =
+                        "If set to true, only user IDs bound to JCR system users are allowed in the user mappings of the 'Sling Service User Mapper Service'. Otherwise all users are allowed!")
         boolean allow_only_system_user() default true;
     }
     /**
@@ -84,12 +88,12 @@ public class JcrSystemUserValidator implements ServiceUserValidator, ServicePrin
     private boolean allowOnlySystemUsers;
 
     /*
-    * We have to prevent a cycle if we are trying to login ourselves. The main idea is that we set the
-    * cycleDetection to true for the current thread before we try to loginService('validation', null).
-    * That way, if we are asked if a user is valid and the cycleDetection is true we know we are in a
-    * cycle and have to shotcut by allowing the user. This should make it so that we use a service user
-    * to valid all service users except our own.
-    */
+     * We have to prevent a cycle if we are trying to login ourselves. The main idea is that we set the
+     * cycleDetection to true for the current thread before we try to loginService('validation', null).
+     * That way, if we are asked if a user is valid and the cycleDetection is true we know we are in a
+     * cycle and have to shotcut by allowing the user. This should make it so that we use a service user
+     * to valid all service users except our own.
+     */
     private final ThreadLocal<Boolean> cycleDetection = new ThreadLocal<Boolean>() {
         @Override
         protected Boolean initialValue() {
@@ -123,11 +127,15 @@ public class JcrSystemUserValidator implements ServiceUserValidator, ServicePrin
             return false;
         }
         if (!allowOnlySystemUsers) {
-            log.debug("There is no enforcement of JCR system users, therefore service user id '{}' is valid", serviceUserId);
+            log.debug(
+                    "There is no enforcement of JCR system users, therefore service user id '{}' is valid",
+                    serviceUserId);
             return true;
         }
         if (validIds.contains(serviceUserId)) {
-            log.debug("The provided service user id '{}' has been already validated and is a known JCR system user id", serviceUserId);
+            log.debug(
+                    "The provided service user id '{}' has been already validated and is a known JCR system user id",
+                    serviceUserId);
             return true;
         } else {
             Session session = null;
@@ -159,7 +167,9 @@ public class JcrSystemUserValidator implements ServiceUserValidator, ServicePrin
                     session.logout();
                 }
             }
-            log.warn("The provided service user id '{}' is not a known JCR system user id and therefore not allowed in the Sling Service User Mapper.", serviceUserId);
+            log.warn(
+                    "The provided service user id '{}' is not a known JCR system user id and therefore not allowed in the Sling Service User Mapper.",
+                    serviceUserId);
             return false;
         }
     }
@@ -175,7 +185,9 @@ public class JcrSystemUserValidator implements ServiceUserValidator, ServicePrin
             return false;
         }
         if (!allowOnlySystemUsers) {
-            log.debug("There is no enforcement of JCR system users, therefore service principal names '{}' are valid", servicePrincipalNames);
+            log.debug(
+                    "There is no enforcement of JCR system users, therefore service principal names '{}' are valid",
+                    servicePrincipalNames);
             return true;
         }
 
@@ -185,7 +197,9 @@ public class JcrSystemUserValidator implements ServiceUserValidator, ServicePrin
         try {
             for (final String pName : servicePrincipalNames) {
                 if (validPrincipalNames.contains(pName)) {
-                    log.debug("The provided service principal name '{}' has been already validated and is a known JCR system user", pName);
+                    log.debug(
+                            "The provided service principal name '{}' has been already validated and is a known JCR system user",
+                            pName);
                 } else {
                     if (session == null) {
                         /*
@@ -210,7 +224,9 @@ public class JcrSystemUserValidator implements ServiceUserValidator, ServicePrin
                         validPrincipalNames.add(pName);
                         log.debug("The provided service principal name {} is a known JCR system user", pName);
                     } else {
-                        log.warn("The provided service principal name '{}' is not a known JCR system user id and therefore not allowed in the Sling Service User Mapper.", pName);
+                        log.warn(
+                                "The provided service principal name '{}' is not a known JCR system user id and therefore not allowed in the Sling Service User Mapper.",
+                                pName);
                         invalid.add(pName);
                     }
                 }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/JcrValueMap.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/JcrValueMap.java
@@ -18,6 +18,12 @@
  */
 package org.apache.sling.jcr.resource.internal;
 
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.PropertyIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
@@ -26,11 +32,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
-import javax.jcr.Node;
-import javax.jcr.Property;
-import javax.jcr.PropertyIterator;
-import javax.jcr.RepositoryException;
-import javax.jcr.Value;
 
 import org.apache.jackrabbit.util.ISO9075;
 import org.apache.jackrabbit.util.Text;
@@ -85,17 +86,17 @@ public class JcrValueMap implements ValueMap {
 
     /**
      * @see org.apache.sling.api.resource.ValueMap#get(java.lang.String, java.lang.Class)
-     * 
+     *
      * Note: The {@code type} parameter is marked as @NonNull in the API documentation, but
      * https://issues.apache.org/jira/browse/SLING-11567 it got obvious that this assumption
      * does not hold true (this change actually broke b/w compatibility).
      * That means we still have to handle the case that {@code type} is null.
-     * 
+     *
      * This is also recommended by the API documentation of this method.
-     * 
+     *
      */
     @Override
-    @SuppressWarnings({"unchecked","java:S2583"})
+    @SuppressWarnings({"unchecked", "java:S2583"})
     public <T> T get(final @NotNull String aKey, @NotNull final Class<T> type) {
         final String key = checkKey(aKey);
         if (type == null) {
@@ -110,17 +111,17 @@ public class JcrValueMap implements ValueMap {
 
     /**
      * @see org.apache.sling.api.resource.ValueMap#get(java.lang.String, java.lang.Object)
-     * 
+     *
      * Note: The {@code defaultValue} parameter is marked as @NonNull in the API documentation, but
      * https://issues.apache.org/jira/browse/SLING-11567 it got obvious that this assumption
      * does not hold true (this change actually broke b/w compatibility).
      * That means we still have to handle the case that {@code defaultValue} is null.
-     * 
+     *
      * This is also recommended by the API documentation of this method.
-     * 
+     *
      */
     @Override
-    @SuppressWarnings({"unchecked","java:S2583"})
+    @SuppressWarnings({"unchecked", "java:S2583"})
     public <T> @NotNull T get(final @NotNull String aKey, @NotNull final T defaultValue) {
         final String key = checkKey(aKey);
         if (defaultValue == null) {
@@ -278,7 +279,8 @@ public class JcrValueMap implements ValueMap {
      * Read a single property.
      * @throws IllegalArgumentException if a repository exception occurs
      */
-    @Nullable JcrPropertyMapCacheEntry read(final @NotNull String name) {
+    @Nullable
+    JcrPropertyMapCacheEntry read(final @NotNull String name) {
         // check for empty key
         if (name.length() == 0) {
             return null;
@@ -296,7 +298,7 @@ public class JcrValueMap implements ValueMap {
 
         try {
             final String key = escapeKeyName(name);
-            Property property = NodeUtil.getPropertyOrNull(node,key);
+            Property property = NodeUtil.getPropertyOrNull(node, key);
             if (property != null) {
                 return cacheProperty(property);
             }
@@ -336,7 +338,7 @@ public class JcrValueMap implements ValueMap {
         }
         final String newPath = sb.toString();
         try {
-            Property property = NodeUtil.getPropertyOrNull(node,newPath);
+            Property property = NodeUtil.getPropertyOrNull(node, newPath);
             if (property != null) {
                 return new JcrPropertyMapCacheEntry(property);
             }
@@ -362,10 +364,7 @@ public class JcrValueMap implements ValueMap {
             final String prefix = key.substring(0, indexOfPrefix);
             for (final String existingPrefix : this.helper.getNamespacePrefixes(this.node.getSession())) {
                 if (existingPrefix.equals(prefix)) {
-                    return prefix
-                            + ":"
-                            + Text.escapeIllegalJcrChars(key
-                            .substring(indexOfPrefix + 1));
+                    return prefix + ":" + Text.escapeIllegalJcrChars(key.substring(indexOfPrefix + 1));
                 }
             }
         }
@@ -406,7 +405,8 @@ public class JcrValueMap implements ValueMap {
         return type;
     }
 
-    private static @NotNull Map<String, Object> transformEntries(final @NotNull Map<String, JcrPropertyMapCacheEntry> map) {
+    private static @NotNull Map<String, Object> transformEntries(
+            final @NotNull Map<String, JcrPropertyMapCacheEntry> map) {
 
         final Map<String, Object> transformedEntries = new LinkedHashMap<>(map.size());
         for (final Map.Entry<String, JcrPropertyMapCacheEntry> entry : map.entrySet())

--- a/src/main/java/org/apache/sling/jcr/resource/internal/NodeUtil.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/NodeUtil.java
@@ -18,17 +18,6 @@
  */
 package org.apache.sling.jcr.resource.internal;
 
-import static javax.jcr.Property.JCR_CONTENT;
-import static javax.jcr.Property.JCR_DATA;
-import static javax.jcr.Property.JCR_FROZEN_PRIMARY_TYPE;
-import static javax.jcr.nodetype.NodeType.NT_FILE;
-import static javax.jcr.nodetype.NodeType.NT_FROZEN_NODE;
-import static javax.jcr.nodetype.NodeType.NT_LINKED_FILE;
-
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-
 import javax.jcr.Item;
 import javax.jcr.ItemNotFoundException;
 import javax.jcr.Node;
@@ -36,12 +25,23 @@ import javax.jcr.Property;
 import javax.jcr.RepositoryException;
 import javax.jcr.nodetype.NodeType;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.apache.jackrabbit.api.JackrabbitNode;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static javax.jcr.Property.JCR_CONTENT;
+import static javax.jcr.Property.JCR_DATA;
+import static javax.jcr.Property.JCR_FROZEN_PRIMARY_TYPE;
+import static javax.jcr.nodetype.NodeType.NT_FILE;
+import static javax.jcr.nodetype.NodeType.NT_FROZEN_NODE;
+import static javax.jcr.nodetype.NodeType.NT_LINKED_FILE;
+
 public abstract class NodeUtil {
-    
+
     private NodeUtil() {}
 
     /**
@@ -51,7 +51,8 @@ public abstract class NodeUtil {
      * @param mixinTypes the mixins
      * @throws RepositoryException if the repository's namespaced prefixes cannot be retrieved
      */
-    public static void handleMixinTypes(final @NotNull Node node, final @Nullable String[] mixinTypes) throws RepositoryException {
+    public static void handleMixinTypes(final @NotNull Node node, final @Nullable String[] mixinTypes)
+            throws RepositoryException {
         final Set<String> newTypes = new HashSet<>();
         if (mixinTypes != null) {
             Collections.addAll(newTypes, mixinTypes);
@@ -75,7 +76,7 @@ public abstract class NodeUtil {
     /**
      * Returns the primary property of the given node. For {@code nt:file} nodes this is a property of the child node {@code jcr:content}.
      * In case the node has a {@code jcr:data} property it is returned, otherwise the node's primary item as specified by its node type recursively until a property is found .
-     * 
+     *
      * @param node the node for which to return the primary property
      * @return the primary property of the given node
      * @throws ItemNotFoundException in case the given node does neither have a {@code jcr:data} property nor a primary property given through its node type
@@ -84,14 +85,18 @@ public abstract class NodeUtil {
     public static @NotNull Property getPrimaryProperty(@NotNull Node node) throws RepositoryException {
         // find the content node: for nt:file it is jcr:content
         // otherwise it is the node of this resource
-        Node content = (node.isNodeType(NT_FILE) ||
-                (node.isNodeType(NT_FROZEN_NODE) &&
-                        node.getProperty(JCR_FROZEN_PRIMARY_TYPE).getString().equals(NT_FILE)))
+        Node content = (node.isNodeType(NT_FILE)
+                        || (node.isNodeType(NT_FROZEN_NODE)
+                                && node.getProperty(JCR_FROZEN_PRIMARY_TYPE)
+                                        .getString()
+                                        .equals(NT_FILE)))
                 ? node.getNode(JCR_CONTENT)
-                : node.isNodeType(NT_LINKED_FILE) ? node.getProperty(JCR_CONTENT).getNode() : node;
+                : node.isNodeType(NT_LINKED_FILE)
+                        ? node.getProperty(JCR_CONTENT).getNode()
+                        : node;
         Property data;
         // if the node has a jcr:data property, use that property
-        final Property property = getPropertyOrNull(content,JCR_DATA);
+        final Property property = getPropertyOrNull(content, JCR_DATA);
         if (property != null) {
             data = property;
         } else {
@@ -117,7 +122,8 @@ public abstract class NodeUtil {
      * @return the property if it exists, null otherwise
      * @throws RepositoryException in case of a problem
      */
-    public static @Nullable Property getPropertyOrNull (@NotNull Node node, @NotNull String propertyName) throws RepositoryException {
+    public static @Nullable Property getPropertyOrNull(@NotNull Node node, @NotNull String propertyName)
+            throws RepositoryException {
         if (node instanceof JackrabbitNode) {
             JackrabbitNode jnode = (JackrabbitNode) node;
             return jnode.getPropertyOrNull(propertyName);
@@ -130,7 +136,8 @@ public abstract class NodeUtil {
         }
     }
 
-    public static @Nullable Node getNodeOrNull (@NotNull Node node, @NotNull String childNode) throws RepositoryException {
+    public static @Nullable Node getNodeOrNull(@NotNull Node node, @NotNull String childNode)
+            throws RepositoryException {
         if (node instanceof JackrabbitNode) {
             JackrabbitNode jnode = (JackrabbitNode) node;
             return jnode.getNodeOrNull(childNode);

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/AccessLogger.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/AccessLogger.java
@@ -1,18 +1,20 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.sling.jcr.resource.internal.helper;
 
@@ -29,10 +31,10 @@ import org.slf4j.LoggerFactory;
 
 /**
  *  Helper class to report on repository access.
- *  
+ *
  *  The focus is to have a less overhead as possible if it is not used; in case it is enabled and access
  *  is logged, the performance overhead does not matter.
- *  
+ *
  *  In the current implementation it has 2 features:
  *  * Write a stacktrace on every recorded operation; this comes with a massive overhead and it is definitely
  *    not recommended to turn this on on production, since it can easily create 100s of megabytes of log and will slow
@@ -40,35 +42,35 @@ import org.slf4j.LoggerFactory;
  *  * When a resource resolver is closed, dump a single log statement about the number of recorded operations. The overhead is
  *    very small and it can be turned on for a longer period of time also in production. To use it enable DEBUG logging on
  *    'org.apache.sling.jcr.resource.AccessLogger.statistics'.
- *  
+ *
  *
  */
 public class AccessLogger implements Closeable {
-    
-    
-    Map<String,AtomicLong> metrics = new HashMap<>();
-    
-    private static final String SELF_NAME= AccessLogger.class.getName();
-    private static final Logger STATISTICS_LOG = LoggerFactory.getLogger("org.apache.sling.jcr.resource.AccessLogger.statistics");
-    private static final Logger OPERATION_LOG  = LoggerFactory.getLogger("org.apache.sling.jcr.resource.AccessLogger.operation");
-    
+
+    Map<String, AtomicLong> metrics = new HashMap<>();
+
+    private static final String SELF_NAME = AccessLogger.class.getName();
+    private static final Logger STATISTICS_LOG =
+            LoggerFactory.getLogger("org.apache.sling.jcr.resource.AccessLogger.statistics");
+    private static final Logger OPERATION_LOG =
+            LoggerFactory.getLogger("org.apache.sling.jcr.resource.AccessLogger.operation");
+
     private final ResourceResolver resolver;
-    
+
     // public
-    
-    
+
     public static void incrementUsage(ResourceResolver resolver, String operation, String path) {
-        incrementUsage(resolver,operation, path, 1);
+        incrementUsage(resolver, operation, path, 1);
     }
-    
+
     public static void incrementUsage(Resource resource, String operation) {
-        incrementUsage(resource.getResourceResolver(),operation, resource.getPath(), 1);
+        incrementUsage(resource.getResourceResolver(), operation, resource.getPath(), 1);
     }
-    
+
     public static void incrementUsage(Resource resource, String operation, long count) {
         incrementUsage(resource.getResourceResolver(), operation, resource.getPath(), count);
     }
-    
+
     public static void incrementUsage(ResourceResolver resolver, String operation, String path, long count) {
 
         if (STATISTICS_LOG.isDebugEnabled()) {
@@ -76,26 +78,25 @@ public class AccessLogger implements Closeable {
             if (am == null) {
                 am = new AccessLogger(resolver);
             }
-            am.incrementUsage(operation,count);
+            am.incrementUsage(operation, count);
         }
         if (OPERATION_LOG.isTraceEnabled()) {
             try {
                 String msg = String.format("invoked %s on [%s]", operation, path);
                 throw new Exception(msg);
             } catch (Exception e) {
-                OPERATION_LOG.trace ("AccessLogger recording", e);
+                OPERATION_LOG.trace("AccessLogger recording", e);
             }
         }
     }
-    
+
     // private
-    
-    private AccessLogger (ResourceResolver resolver) {
+
+    private AccessLogger(ResourceResolver resolver) {
         this.resolver = resolver;
-        resolver.getPropertyMap().put(SELF_NAME,this);
+        resolver.getPropertyMap().put(SELF_NAME, this);
     }
-    
-    
+
     private void incrementUsage(String operation, long count) {
         AtomicLong meter = metrics.get(operation);
         if (meter == null) {
@@ -104,26 +105,22 @@ public class AccessLogger implements Closeable {
             meter.addAndGet(count);
         }
     }
-    
+
     @Override
     public String toString() {
         String values = metrics.keySet().stream()
-            .map(key -> key + "=" + metrics.get(key).get())
-            .collect(Collectors.joining(","));
-        
+                .map(key -> key + "=" + metrics.get(key).get())
+                .collect(Collectors.joining(","));
+
         return "AccessLogger (" + values + ")";
     }
 
-
     @Override
     public void close() {
-        STATISTICS_LOG.debug("AccessLogger dump for ResourceResolver (userid={},tostring={}): {}", resolver.getUserID(), resolver, this);
+        STATISTICS_LOG.debug(
+                "AccessLogger dump for ResourceResolver (userid={},tostring={}): {}",
+                resolver.getUserID(),
+                resolver,
+                this);
     }
-    
-    
-    
-    
-    
-    
-
 }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/BooleanConverter.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/BooleanConverter.java
@@ -18,12 +18,12 @@
  */
 package org.apache.sling.jcr.resource.internal.helper;
 
-import org.jetbrains.annotations.NotNull;
-
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Date;
+
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A converter for Boolean

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/CalendarConverter.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/CalendarConverter.java
@@ -39,7 +39,8 @@ public class CalendarConverter extends NumberConverter implements Converter {
 
     @Override
     public @NotNull ZonedDateTime toZonedDateTime() {
-        return ZonedDateTime.ofInstant(this.value.toInstant(), this.value.getTimeZone().toZoneId().normalized());
+        return ZonedDateTime.ofInstant(
+                this.value.toInstant(), this.value.getTimeZone().toZoneId().normalized());
     }
 
     /**

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/Converter.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/Converter.java
@@ -18,12 +18,12 @@
  */
 package org.apache.sling.jcr.resource.internal.helper;
 
-import org.jetbrains.annotations.NotNull;
-
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Date;
+
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A converter converts a value to a specific target type.
@@ -35,75 +35,85 @@ public interface Converter {
      * @return Long representation of the converted value
      * @throws NumberFormatException if the conversion fails
      */
-    @NotNull Long toLong();
+    @NotNull
+    Long toLong();
 
     /**
      * Convert to Byte.
      * @return Byte representation of the converted value
      * @throws NumberFormatException if the conversion fails
      */
-    @NotNull Byte toByte();
+    @NotNull
+    Byte toByte();
 
     /**
      * Convert to Short.
      * @return Short representation of the converted value
      * @throws NumberFormatException if the conversion fails
      */
-    @NotNull Short toShort();
+    @NotNull
+    Short toShort();
 
     /**
      * Convert to Integer.
      * @return Integer representation of the converted value
      * @throws NumberFormatException if the conversion fails
      */
-    @NotNull Integer toInteger();
+    @NotNull
+    Integer toInteger();
 
     /**
      * Convert to Double.
      * @return Double representation of the converted value
      * @throws NumberFormatException if the conversion fails
      */
-    @NotNull Double toDouble();
+    @NotNull
+    Double toDouble();
 
     /**
      * Convert to Float.
      * @return Float representation of the converted value
      * @throws NumberFormatException if the conversion fails
      */
-    @NotNull Float toFloat();
+    @NotNull
+    Float toFloat();
 
     /**
      * Convert to ZonedDateTime.
      * @return Calendar representation of the converted value
      * @throws IllegalArgumentException  if the value cannot be parsed into a calendar
      */
-    @NotNull ZonedDateTime toZonedDateTime();
+    @NotNull
+    ZonedDateTime toZonedDateTime();
 
     /**
      * Convert to Calendar.
      * @return Calendar representation of the converted value
      * @throws IllegalArgumentException  if the value cannot be parsed into a calendar
      */
-    @NotNull Calendar toCalendar();
+    @NotNull
+    Calendar toCalendar();
 
     /**
      * Convert to Date.
      * @return Date representation of the converted value
      * @throws IllegalArgumentException  if the value cannot be parsed into a date
      */
-    @NotNull Date toDate();
+    @NotNull
+    Date toDate();
 
     /**
      * Convert to boolean.
      * @return  Boolean representation of the converted value
      */
-    @NotNull Boolean toBoolean();
+    @NotNull
+    Boolean toBoolean();
 
     /**
      * Convert to BigDecimal.
      * @return BigDecimal representation of the converted value
      * @throws NumberFormatException if the conversion fails
      */
-    @NotNull BigDecimal toBigDecimal();
-
+    @NotNull
+    BigDecimal toBigDecimal();
 }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/JcrPropertyMapCacheEntry.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/JcrPropertyMapCacheEntry.java
@@ -1,20 +1,30 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with this
- * work for additional information regarding copyright ownership. The ASF
- * licenses this file to You under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.sling.jcr.resource.internal.helper;
+
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.PropertyType;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Value;
+import javax.jcr.ValueFormatException;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -32,14 +42,6 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
-
-import javax.jcr.Node;
-import javax.jcr.Property;
-import javax.jcr.PropertyType;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import javax.jcr.Value;
-import javax.jcr.ValueFormatException;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.jetbrains.annotations.NotNull;
@@ -83,7 +85,8 @@ public class JcrPropertyMapCacheEntry {
      * @param node the node
      * @throws RepositoryException if the provided value cannot be stored
      */
-    public JcrPropertyMapCacheEntry(final @NotNull Object value, final @NotNull Node node) throws IOException, RepositoryException {
+    public JcrPropertyMapCacheEntry(final @NotNull Object value, final @NotNull Node node)
+            throws IOException, RepositoryException {
         this.property = null;
         this.propertyValue = value;
         this.isArray = value.getClass().isArray();
@@ -98,7 +101,8 @@ public class JcrPropertyMapCacheEntry {
         }
     }
 
-    private static void failIfCannotStore(final @NotNull Object value, final @NotNull Node node) throws IOException, RepositoryException {
+    private static void failIfCannotStore(final @NotNull Object value, final @NotNull Node node)
+            throws IOException, RepositoryException {
         if (value instanceof InputStream) {
             // InputStream is storable and calling createValue for nothing
             // eats its contents
@@ -106,7 +110,8 @@ public class JcrPropertyMapCacheEntry {
         }
         final Value val = createValue(value, node);
         if (val == null) {
-            throw new IllegalArgumentException("Value can't be stored in the repository as it is having an unsupported type " + value.getClass());
+            throw new IllegalArgumentException(
+                    "Value can't be stored in the repository as it is having an unsupported type " + value.getClass());
         }
     }
 
@@ -120,7 +125,8 @@ public class JcrPropertyMapCacheEntry {
      * @param  node the node
      * @return the converted value
      */
-    private static @Nullable Value createValue(final @NotNull Object obj, final @NotNull Node node) throws IOException, RepositoryException {
+    private static @Nullable Value createValue(final @NotNull Object obj, final @NotNull Node node)
+            throws IOException, RepositoryException {
         final Session session = node.getSession();
         Value value = JcrResourceUtil.createValue(obj, session);
         if (value == null && obj instanceof Serializable) {
@@ -129,7 +135,8 @@ public class JcrPropertyMapCacheEntry {
             oos.writeObject(obj);
             oos.close();
             final ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
-            value = session.getValueFactory().createValue(session.getValueFactory().createBinary(bais));
+            value = session.getValueFactory()
+                    .createValue(session.getValueFactory().createBinary(bais));
         }
         return value;
     }
@@ -201,9 +208,8 @@ public class JcrPropertyMapCacheEntry {
      * @return The converted object
      */
     @SuppressWarnings("unchecked")
-    public @Nullable<T> T convertToType(final @NotNull Class<T> type,
-                                        final @NotNull Node node,
-                                        final @Nullable ClassLoader dynamicClassLoader){
+    public @Nullable <T> T convertToType(
+            final @NotNull Class<T> type, final @NotNull Node node, final @Nullable ClassLoader dynamicClassLoader) {
         T result = null;
 
         try {
@@ -238,11 +244,12 @@ public class JcrPropertyMapCacheEntry {
         return result;
     }
 
-    private @NotNull<T> T[] convertToArray(final @NotNull Object source,
-                                           final @NotNull Class<T> type,
-                                           final @NotNull Node node,
-                                           final @Nullable ClassLoader dynamicClassLoader)
-    throws IOException, RepositoryException {
+    private @NotNull <T> T[] convertToArray(
+            final @NotNull Object source,
+            final @NotNull Class<T> type,
+            final @NotNull Node node,
+            final @Nullable ClassLoader dynamicClassLoader)
+            throws IOException, RepositoryException {
         List<T> values = new ArrayList<>();
         T value = convertToType(-1, source, type, node, dynamicClassLoader);
         if (value != null) {
@@ -254,11 +261,12 @@ public class JcrPropertyMapCacheEntry {
         return values.toArray(result);
     }
 
-    private @NotNull<T> T[] convertToArray(final @NotNull Object[] sourceArray,
-                                           final @NotNull Class<T> type,
-                                           final @NotNull Node node,
-                                           final @Nullable ClassLoader dynamicClassLoader)
-    throws IOException, RepositoryException {
+    private @NotNull <T> T[] convertToArray(
+            final @NotNull Object[] sourceArray,
+            final @NotNull Class<T> type,
+            final @NotNull Node node,
+            final @Nullable ClassLoader dynamicClassLoader)
+            throws IOException, RepositoryException {
         List<T> values = new ArrayList<>();
         for (int i = 0; i < sourceArray.length; i++) {
             T value = convertToType(i, sourceArray[i], type, node, dynamicClassLoader);
@@ -274,12 +282,13 @@ public class JcrPropertyMapCacheEntry {
     }
 
     @SuppressWarnings("unchecked")
-    private @Nullable<T> T convertToType(final int index,
-                                         final @NotNull Object initialValue,
-                                         final @NotNull Class<T> type,
-                                         final @NotNull Node node,
-                                         final @Nullable ClassLoader dynamicClassLoader)
-    throws IOException, RepositoryException {
+    private @Nullable <T> T convertToType(
+            final int index,
+            final @NotNull Object initialValue,
+            final @NotNull Class<T> type,
+            final @NotNull Node node,
+            final @Nullable ClassLoader dynamicClassLoader)
+            throws IOException, RepositoryException {
         if (type.isInstance(initialValue)) {
             return (T) initialValue;
         }
@@ -291,12 +300,13 @@ public class JcrPropertyMapCacheEntry {
         }
     }
 
-    private @Nullable <T> T convertInputStream(int index,
-                                               final @NotNull InputStream value,
-                                               final @NotNull Class<T> type,
-                                               final @NotNull Node node,
-                                               final @Nullable ClassLoader dynamicClassLoader)
-    throws IOException, RepositoryException {
+    private @Nullable <T> T convertInputStream(
+            int index,
+            final @NotNull InputStream value,
+            final @NotNull Class<T> type,
+            final @NotNull Node node,
+            final @Nullable ClassLoader dynamicClassLoader)
+            throws IOException, RepositoryException {
         // object input stream
         if (ObjectInputStream.class.isAssignableFrom(type)) {
             try {
@@ -305,7 +315,7 @@ public class JcrPropertyMapCacheEntry {
                 // ignore and use fallback
             }
 
-        // any number: length of binary
+            // any number: length of binary
         } else if (Number.class.isAssignableFrom(type)) {
             // avoid NPE if this instance has not been created from a property (see SLING-11465)
             if (property == null) {
@@ -313,11 +323,11 @@ public class JcrPropertyMapCacheEntry {
             }
             return convert(propertyToLength(property, index), type, node);
 
-        // string: read binary
+            // string: read binary
         } else if (String.class == type) {
             return (T) inputStreamToString(value);
 
-        // any serializable
+            // any serializable
         } else if (Serializable.class.isAssignableFrom(type)) {
             try (ObjectInputStream ois = new PropertyObjectInputStream(value, dynamicClassLoader)) {
                 final Object obj = ois.readObject();
@@ -359,10 +369,8 @@ public class JcrPropertyMapCacheEntry {
         }
     }
 
-    private @Nullable <T> T convert(final @NotNull Object value,
-                                   final @NotNull Class<T> type,
-                                   final @NotNull Node node)
-    throws IOException, RepositoryException {
+    private @Nullable <T> T convert(final @NotNull Object value, final @NotNull Class<T> type, final @NotNull Node node)
+            throws IOException, RepositoryException {
         if (String.class == type) {
             return (T) getConverter(value).toString();
 
@@ -398,7 +406,8 @@ public class JcrPropertyMapCacheEntry {
 
         } else if (ZonedDateTime.class == type) {
             Calendar calendar = getConverter(value).toCalendar();
-            return (T) ZonedDateTime.ofInstant(calendar.toInstant(), calendar.getTimeZone().toZoneId().normalized());
+            return (T) ZonedDateTime.ofInstant(
+                    calendar.toInstant(), calendar.getTimeZone().toZoneId().normalized());
 
         } else if (Value.class == type) {
             return (T) createValue(value, node);
@@ -442,7 +451,8 @@ public class JcrPropertyMapCacheEntry {
 
         private final ClassLoader classloader;
 
-        public PropertyObjectInputStream(final @NotNull InputStream in, final @Nullable ClassLoader classLoader) throws IOException {
+        public PropertyObjectInputStream(final @NotNull InputStream in, final @Nullable ClassLoader classLoader)
+                throws IOException {
             super(in);
             this.classloader = classLoader;
         }
@@ -451,8 +461,7 @@ public class JcrPropertyMapCacheEntry {
          * @see java.io.ObjectInputStream#resolveClass(java.io.ObjectStreamClass)
          */
         @Override
-        protected Class<?> resolveClass(final ObjectStreamClass classDesc)
-                throws IOException, ClassNotFoundException {
+        protected Class<?> resolveClass(final ObjectStreamClass classDesc) throws IOException, ClassNotFoundException {
             if (this.classloader != null) {
                 return this.classloader.loadClass(classDesc.getName());
             }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/JcrResourceUtil.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/JcrResourceUtil.java
@@ -18,14 +18,6 @@
  */
 package org.apache.sling.jcr.resource.internal.helper;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import java.io.InputStream;
-import java.math.BigDecimal;
-import java.time.ZonedDateTime;
-import java.util.Calendar;
-
 import javax.jcr.Node;
 import javax.jcr.Property;
 import javax.jcr.PropertyType;
@@ -37,13 +29,21 @@ import javax.jcr.query.Query;
 import javax.jcr.query.QueryManager;
 import javax.jcr.query.QueryResult;
 
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 /**
  * The <code>JcrResourceUtil</code> class provides helper methods used
  * throughout this bundle.
  *
  */
 public class JcrResourceUtil {
-    
+
     private JcrResourceUtil() {}
 
     /**
@@ -55,7 +55,8 @@ public class JcrResourceUtil {
      * @return the query's result
      * @throws RepositoryException if the {@link QueryManager} cannot be retrieved
      */
-    public static @NotNull QueryResult query(@NotNull Session session, @NotNull String query, @NotNull String language) throws RepositoryException {
+    public static @NotNull QueryResult query(@NotNull Session session, @NotNull String query, @NotNull String language)
+            throws RepositoryException {
         QueryManager qManager = session.getWorkspace().getQueryManager();
         Query q = qManager.createQuery(query, language);
         return q.execute();
@@ -82,7 +83,8 @@ public class JcrResourceUtil {
                 return value.getDouble();
             case PropertyType.LONG:
                 return value.getLong();
-            // all other types (NAME, PATH, REFERENCE, WEAKREFERENCE, STRING, URI, UNDEFINED) fallback to string representation
+            // all other types (NAME, PATH, REFERENCE, WEAKREFERENCE, STRING, URI, UNDEFINED) fallback to string
+            // representation
             default:
                 return value.getString();
         }
@@ -97,8 +99,7 @@ public class JcrResourceUtil {
      * @throws RepositoryException if the conversion cannot take place
      * @return the Object resulting from the conversion
      */
-    public static @NotNull Object toJavaObject(@NotNull Property property)
-            throws RepositoryException {
+    public static @NotNull Object toJavaObject(@NotNull Property property) throws RepositoryException {
         // multi-value property: return an array of values
         if (property.isMultiple()) {
             Value[] values = property.getValues();
@@ -116,7 +117,7 @@ public class JcrResourceUtil {
         // single value property
         return toJavaObject(property.getValue());
     }
-    
+
     private static @NotNull Object[] createArray(@Nullable Object firstValue, int length) {
         Object[] result;
         if (firstValue instanceof Boolean) {
@@ -148,7 +149,8 @@ public class JcrResourceUtil {
      * @return the value or null if not convertible to a valid PropertyType
      * @throws RepositoryException in case of error, accessing the Repository
      */
-    public static @Nullable Value createValue(final @NotNull Object value, final @NotNull Session session) throws RepositoryException {
+    public static @Nullable Value createValue(final @NotNull Object value, final @NotNull Session session)
+            throws RepositoryException {
         Value val;
         ValueFactory fac = session.getValueFactory();
         if (value instanceof ZonedDateTime) {

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/LazyInputStream.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/LazyInputStream.java
@@ -18,13 +18,13 @@
  */
 package org.apache.sling.jcr.resource.internal.helper;
 
-import org.jetbrains.annotations.NotNull;
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
 
 import java.io.IOException;
 import java.io.InputStream;
 
-import javax.jcr.RepositoryException;
-import javax.jcr.Value;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Lazily acquired InputStream which only accesses the JCR Value InputStream if
@@ -112,5 +112,4 @@ public class LazyInputStream extends InputStream {
         }
         return delegatee;
     }
-
 }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/NumberConverter.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/NumberConverter.java
@@ -18,12 +18,12 @@
  */
 package org.apache.sling.jcr.resource.internal.helper;
 
-import org.jetbrains.annotations.NotNull;
-
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Date;
+
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A converter for Number

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/ZonedDateTimeConverter.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/ZonedDateTimeConverter.java
@@ -18,10 +18,10 @@
  */
 package org.apache.sling.jcr.resource.internal.helper;
 
-import org.jetbrains.annotations.NotNull;
-
 import java.time.ZonedDateTime;
 import java.util.GregorianCalendar;
+
+import org.jetbrains.annotations.NotNull;
 
 public class ZonedDateTimeConverter extends CalendarConverter {
 

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/BasicQueryLanguageProvider.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/BasicQueryLanguageProvider.java
@@ -18,17 +18,17 @@
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.NoSuchElementException;
-
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 import javax.jcr.query.Query;
 import javax.jcr.query.QueryResult;
 import javax.jcr.query.Row;
 import javax.jcr.query.RowIterator;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.sling.api.SlingException;
@@ -77,13 +77,14 @@ public class BasicQueryLanguageProvider implements QueryLanguageProvider<JcrProv
     }
 
     @Override
-    public Iterator<Resource> findResources(final @NotNull ResolveContext<JcrProviderState> ctx,
-                                            final String query,
-                                            final String language) {
+    public Iterator<Resource> findResources(
+            final @NotNull ResolveContext<JcrProviderState> ctx, final String query, final String language) {
         try {
             final QueryResult res = JcrResourceUtil.query(getSession(ctx), query, language);
-            return new JcrNodeResourceIterator(ctx.getResourceResolver(),
-                    null, null,
+            return new JcrNodeResourceIterator(
+                    ctx.getResourceResolver(),
+                    null,
+                    null,
                     res.getNodes(),
                     getHelperData(ctx),
                     this.providerContext.getExcludedPaths());
@@ -95,10 +96,10 @@ public class BasicQueryLanguageProvider implements QueryLanguageProvider<JcrProv
     }
 
     @Override
-    public Iterator<ValueMap> queryResources(final @NotNull ResolveContext<JcrProviderState> ctx,
-                                             final String query,
-                                             final String language) {
-        final String queryLanguage = ArrayUtils.contains(getSupportedLanguages(ctx), language) ? language : DEFAULT_QUERY_LANGUAGE;
+    public Iterator<ValueMap> queryResources(
+            final @NotNull ResolveContext<JcrProviderState> ctx, final String query, final String language) {
+        final String queryLanguage =
+                ArrayUtils.contains(getSupportedLanguages(ctx), language) ? language : DEFAULT_QUERY_LANGUAGE;
 
         try {
             final QueryResult result = JcrResourceUtil.query(getSession(ctx), query, queryLanguage);
@@ -131,7 +132,7 @@ public class BasicQueryLanguageProvider implements QueryLanguageProvider<JcrProv
 
         @Override
         public ValueMap next() {
-            if ( next == null ) {
+            if (next == null) {
                 throw new NoSuchElementException();
             }
             final ValueMap result = next;
@@ -145,7 +146,8 @@ public class BasicQueryLanguageProvider implements QueryLanguageProvider<JcrProv
                 try {
                     final Row jcrRow = rows.nextRow();
                     final String resourcePath = jcrRow.getPath();
-                    if (resourcePath != null && providerContext.getExcludedPaths().matches(resourcePath) == null) {
+                    if (resourcePath != null
+                            && providerContext.getExcludedPaths().matches(resourcePath) == null) {
                         result = new ValueMapDecorator(getRow(jcrRow));
                     }
                 } catch (final RepositoryException re) {

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/BinaryDownloadUriProvider.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/BinaryDownloadUriProvider.java
@@ -1,28 +1,30 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
-
-import java.net.URI;
 
 import javax.jcr.Binary;
 import javax.jcr.ItemNotFoundException;
 import javax.jcr.Node;
 import javax.jcr.Property;
 import javax.jcr.RepositoryException;
+
+import java.net.URI;
 
 import org.apache.jackrabbit.api.binary.BinaryDownload;
 import org.apache.jackrabbit.api.binary.BinaryDownloadOptions;
@@ -41,7 +43,7 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 /**
  * Provides URIs for direct binary read-access based on the Jackrabbit API {@link BinaryDownload}.
- * 
+ *
  * @see <a href="https://jackrabbit.apache.org/oak/docs/features/direct-binary-access.html">Oak Direct Binary Access</a>
  *
  */
@@ -57,7 +59,8 @@ public class BinaryDownloadUriProvider implements URIProvider {
 
     @ObjectClassDefinition(
             name = "Apache Sling Binary Download URI Provider",
-            description = "Provides URIs for resources containing a primary JCR binary property backed by a blob store allowing direct HTTP access")
+            description =
+                    "Provides URIs for resources containing a primary JCR binary property backed by a blob store allowing direct HTTP access")
     public static @interface Configuration {
         @AttributeDefinition(
                 name = "Content-Disposition",
@@ -79,7 +82,9 @@ public class BinaryDownloadUriProvider implements URIProvider {
     @Override
     public @NotNull URI toURI(@NotNull Resource resource, @NotNull Scope scope, @NotNull Operation operation) {
         if (!isRelevantScopeAndOperation(scope, operation)) {
-            throw new IllegalArgumentException("This provider only provides URIs for 'READ' operations in scope 'PUBLIC' or 'EXTERNAL', but not for scope '" + scope + "' and operation '" + operation + "'");
+            throw new IllegalArgumentException(
+                    "This provider only provides URIs for 'READ' operations in scope 'PUBLIC' or 'EXTERNAL', but not for scope '"
+                            + scope + "' and operation '" + operation + "'");
         }
         Node node = resource.adaptTo(Node.class);
         if (node == null) {
@@ -91,7 +96,8 @@ public class BinaryDownloadUriProvider implements URIProvider {
             try {
                 return getUriFromProperty(resource, node, primaryProperty);
             } catch (RepositoryException e) {
-                throw new IllegalArgumentException("Error getting URI for property '" + primaryProperty.getPath() + "'", e);
+                throw new IllegalArgumentException(
+                        "Error getting URI for property '" + primaryProperty.getPath() + "'", e);
             }
         } catch (ItemNotFoundException e) {
             throw new IllegalArgumentException("Node does not have a primary property", e);
@@ -108,18 +114,22 @@ public class BinaryDownloadUriProvider implements URIProvider {
         return ((Scope.PUBLIC.equals(scope) || Scope.EXTERNAL.equals(scope)) && Operation.READ.equals(operation));
     }
 
-    private @NotNull URI getUriFromProperty(@NotNull Resource resource, @NotNull Node node, @NotNull Property binaryProperty) throws RepositoryException {
+    private @NotNull URI getUriFromProperty(
+            @NotNull Resource resource, @NotNull Node node, @NotNull Property binaryProperty)
+            throws RepositoryException {
         Binary binary = binaryProperty.getBinary();
         if (!(binary instanceof BinaryDownload)) {
             binary.dispose();
-            throw new IllegalArgumentException("The property " + binaryProperty.getPath() + " is not backed by a blob store allowing direct HTTP access");
+            throw new IllegalArgumentException("The property " + binaryProperty.getPath()
+                    + " is not backed by a blob store allowing direct HTTP access");
         }
         BinaryDownload binaryDownload = BinaryDownload.class.cast(binary);
         try {
             String encoding = resource.getResourceMetadata().getCharacterEncoding();
             String fileName = node.getName();
             String mediaType = resource.getResourceMetadata().getContentType();
-            BinaryDownloadOptionsBuilder optionsBuilder = BinaryDownloadOptions.builder().withFileName(fileName);
+            BinaryDownloadOptionsBuilder optionsBuilder =
+                    BinaryDownloadOptions.builder().withFileName(fileName);
             if (encoding != null) {
                 optionsBuilder.withCharacterEncoding(encoding);
             }
@@ -133,12 +143,12 @@ public class BinaryDownloadUriProvider implements URIProvider {
             }
             URI uri = binaryDownload.getURI(optionsBuilder.build());
             if (uri == null) {
-                throw new IllegalArgumentException("Cannot provide url for downloading the binary property at '" + binaryProperty.getPath() + "'");
+                throw new IllegalArgumentException(
+                        "Cannot provide url for downloading the binary property at '" + binaryProperty.getPath() + "'");
             }
             return uri;
         } finally {
             binaryDownload.dispose();
         }
     }
-
 }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/ContextUtil.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/ContextUtil.java
@@ -1,26 +1,28 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
+
+import javax.jcr.Session;
 
 import org.apache.sling.jcr.resource.internal.HelperData;
 import org.apache.sling.spi.resource.provider.ResolveContext;
 import org.jetbrains.annotations.NotNull;
-
-import javax.jcr.Session;
 
 final class ContextUtil {
 
@@ -39,8 +41,8 @@ final class ContextUtil {
     }
 
     /**
-     * As long as the provider is active there must be a state available. 
-     * 
+     * As long as the provider is active there must be a state available.
+     *
      * @param ctx the {@code ResolveContext}
      * @return the {@code JcrProviderState} associated with the given context.
      */

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrExternalizableInputStream.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrExternalizableInputStream.java
@@ -1,32 +1,32 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-
 package org.apache.sling.jcr.resource.internal.helper.jcr;
-
-
-
-import org.apache.sling.api.resource.external.ExternalizableInputStream;
-import org.jetbrains.annotations.NotNull;
 
 import javax.jcr.Property;
 import javax.jcr.RepositoryException;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+
+import org.apache.sling.api.resource.external.ExternalizableInputStream;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A lazy initialised input stream wrapping a JCR Property that also has a Public URI representation. The
@@ -41,7 +41,7 @@ public class JcrExternalizableInputStream extends InputStream implements Externa
     private final Property data;
     private final URI uri;
     private InputStream inputStream;
-    
+
     /**
      * Construct the InputStream wrapping this existing stream and
      * using a public URI
@@ -78,5 +78,4 @@ public class JcrExternalizableInputStream extends InputStream implements Externa
     public @NotNull URI getURI() {
         return uri;
     }
-
 }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrItemResource.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrItemResource.java
@@ -18,15 +18,15 @@
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Iterator;
-
 import javax.jcr.Item;
 import javax.jcr.Node;
 import javax.jcr.Property;
 import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
 import javax.jcr.ValueFormatException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
 
 import org.apache.sling.api.resource.AbstractResource;
 import org.apache.sling.api.resource.Resource;
@@ -40,7 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 abstract class JcrItemResource<T extends Item> // this should be package private, see SLING-1414
-    extends AbstractResource {
+        extends AbstractResource {
 
     /**
      * default log
@@ -57,11 +57,12 @@ abstract class JcrItemResource<T extends Item> // this should be package private
 
     private final ResourceMetadata metadata;
 
-    protected JcrItemResource(final @NotNull ResourceResolver resourceResolver,
-                              final @NotNull String path,
-                              final @Nullable String version,
-                              final @NotNull T item,
-                              final @NotNull ResourceMetadata metadata) {
+    protected JcrItemResource(
+            final @NotNull ResourceResolver resourceResolver,
+            final @NotNull String path,
+            final @Nullable String version,
+            final @NotNull T item,
+            final @NotNull ResourceMetadata metadata) {
 
         this.resourceResolver = resourceResolver;
         this.path = path;
@@ -163,6 +164,6 @@ abstract class JcrItemResource<T extends Item> // this should be package private
      * Returns an iterator over the child resources or <code>null</code> if
      * there are none.
      */
-    @Nullable abstract Iterator<Resource> listJcrChildren();
-
+    @Nullable
+    abstract Iterator<Resource> listJcrChildren();
 }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrItemResourceFactory.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrItemResourceFactory.java
@@ -18,9 +18,6 @@
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
-import java.util.LinkedList;
-import java.util.Map;
-
 import javax.jcr.Item;
 import javax.jcr.Node;
 import javax.jcr.Property;
@@ -29,6 +26,9 @@ import javax.jcr.Session;
 import javax.jcr.nodetype.NodeType;
 import javax.jcr.version.VersionHistory;
 import javax.jcr.version.VersionManager;
+
+import java.util.LinkedList;
+import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.api.JackrabbitSession;
@@ -74,15 +74,19 @@ public class JcrItemResourceFactory {
      * @throws RepositoryException If an error occurs accessing checking the
      *             item in the repository.
      */
-    public @Nullable JcrItemResource<?> createResource(final @NotNull ResourceResolver resourceResolver, final @NotNull String resourcePath,
-                                                       final @Nullable Resource parent, final @Nullable Map<String, String> parameters) throws RepositoryException {
+    public @Nullable JcrItemResource<?> createResource(
+            final @NotNull ResourceResolver resourceResolver,
+            final @NotNull String resourcePath,
+            final @Nullable Resource parent,
+            final @Nullable Map<String, String> parameters)
+            throws RepositoryException {
         final String version;
         if (parameters != null && parameters.containsKey("v")) {
             version = parameters.get("v");
         } else {
             version = null;
         }
-        
+
         Item item = getItem(resourcePath, parent, version);
 
         if (item == null) {
@@ -106,15 +110,17 @@ public class JcrItemResourceFactory {
             return resource;
         }
     }
-    
-    private @Nullable Item getItem(@NotNull String resourcePath, @Nullable Resource parent, @Nullable String versionSpecifier) throws RepositoryException {
+
+    private @Nullable Item getItem(
+            @NotNull String resourcePath, @Nullable Resource parent, @Nullable String versionSpecifier)
+            throws RepositoryException {
         Node parentNode = null;
         String parentResourcePath = null;
         if (parent != null) {
             parentNode = parent.adaptTo(Node.class);
             parentResourcePath = parent.getPath();
         }
-        
+
         Item item;
         if (parentNode != null && resourcePath.startsWith(parentResourcePath)) {
             String subPath = resourcePath.substring(parentResourcePath.length());
@@ -131,7 +137,7 @@ public class JcrItemResourceFactory {
         }
         return item;
     }
-    
+
     private @Nullable Item getHistoricItem(Item item, String versionSpecifier) throws RepositoryException {
         Item currentItem = item;
         LinkedList<String> relPath = new LinkedList<>();
@@ -167,7 +173,8 @@ public class JcrItemResourceFactory {
         }
     }
 
-    private @Nullable Node getFrozenNode(@NotNull Node node, @NotNull String versionSpecifier) throws RepositoryException {
+    private @Nullable Node getFrozenNode(@NotNull Node node, @NotNull String versionSpecifier)
+            throws RepositoryException {
         final VersionManager versionManager = session.getWorkspace().getVersionManager();
         final VersionHistory history = versionManager.getVersionHistory(node.getPath());
         if (history.hasVersionLabel(versionSpecifier)) {
@@ -183,7 +190,8 @@ public class JcrItemResourceFactory {
         return item.isNode() && ((Node) item).isNodeType(NodeType.MIX_VERSIONABLE);
     }
 
-    @Nullable Item getItemOrNull(@NotNull String path) {
+    @Nullable
+    Item getItemOrNull(@NotNull String path) {
         // Check first if the path is absolute. If it isn't, then we return null because the previous itemExists method,
         // which was replaced by this method, would have returned null as well (instead of throwing an exception).
         if (path.isEmpty() || path.charAt(0) != '/') {
@@ -210,7 +218,8 @@ public class JcrItemResourceFactory {
         return item;
     }
 
-    @Nullable Node getParentOrNull(@NotNull Item child, @NotNull String parentPath) {
+    @Nullable
+    Node getParentOrNull(@NotNull Item child, @NotNull String parentPath) {
         Node parent = null;
         try {
             // Use fast getParentOrNull if session is a JackrabbitSession
@@ -226,5 +235,4 @@ public class JcrItemResourceFactory {
 
         return parent;
     }
-
 }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrNodeResource.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrNodeResource.java
@@ -1,26 +1,22 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
-
-import java.io.InputStream;
-import java.net.URI;
-import java.security.AccessControlException;
-import java.util.Iterator;
-import java.util.Map;
 
 import javax.jcr.Item;
 import javax.jcr.ItemNotFoundException;
@@ -28,6 +24,12 @@ import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.Property;
 import javax.jcr.RepositoryException;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.security.AccessControlException;
+import java.util.Iterator;
+import java.util.Map;
 
 import org.apache.sling.adapter.annotations.Adaptable;
 import org.apache.sling.adapter.annotations.Adapter;
@@ -49,11 +51,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** A Resource that wraps a JCR Node */
-@Adaptable(adaptableClass=Resource.class, adapters={
-        @Adapter({Node.class, Map.class, Item.class, ValueMap.class}),
-        @Adapter(value=InputStream.class, condition="If the resource is a JcrNodeResource and has a jcr:data property or is an nt:file node."),
-        @Adapter(value=ExternalizableInputStream.class, condition="If the resource is a JcrNodeResource and has a jcr:data property or is an nt:file node, and can be read using a secure URL.")
-})
+@Adaptable(
+        adaptableClass = Resource.class,
+        adapters = {
+            @Adapter({Node.class, Map.class, Item.class, ValueMap.class}),
+            @Adapter(
+                    value = InputStream.class,
+                    condition =
+                            "If the resource is a JcrNodeResource and has a jcr:data property or is an nt:file node."),
+            @Adapter(
+                    value = ExternalizableInputStream.class,
+                    condition =
+                            "If the resource is a JcrNodeResource and has a jcr:data property or is an nt:file node, and can be read using a secure URL.")
+        })
 class JcrNodeResource extends JcrItemResource<Node> { // this should be package private, see SLING-1414
 
     /** marker value for the resourceSuperType before trying to evaluate */
@@ -75,11 +85,12 @@ class JcrNodeResource extends JcrItemResource<Node> { // this should be package 
      * @param node The Node underlying this resource
      * @param helper The helper providing access to dynamic class loader for loading serialized objects and uri provider reference.
      */
-    public JcrNodeResource(final @NotNull ResourceResolver resourceResolver,
-                           final @NotNull String path,
-                           final @Nullable String version,
-                           final @NotNull Node node,
-                           final @NotNull HelperData helper) {
+    public JcrNodeResource(
+            final @NotNull ResourceResolver resourceResolver,
+            final @NotNull String path,
+            final @Nullable String version,
+            final @NotNull Node node,
+            final @NotNull HelperData helper) {
         super(resourceResolver, path, version, node, new JcrNodeResourceMetadata(node));
         this.helper = helper;
         this.resourceSuperType = UNSET_RESOURCE_SUPER_TYPE;
@@ -110,7 +121,8 @@ class JcrNodeResource extends JcrItemResource<Node> { // this should be package 
         // Yes, this isn't how you're supposed to compare Strings, but this is intentional.
         if (resourceSuperType == UNSET_RESOURCE_SUPER_TYPE) {
             try {
-                Property property = NodeUtil.getPropertyOrNull(getNode(), JcrResourceConstants.SLING_RESOURCE_SUPER_TYPE_PROPERTY);
+                Property property =
+                        NodeUtil.getPropertyOrNull(getNode(), JcrResourceConstants.SLING_RESOURCE_SUPER_TYPE_PROPERTY);
                 if (property != null) {
                     resourceSuperType = property.getValue().getString();
                 }
@@ -141,14 +153,10 @@ class JcrNodeResource extends JcrItemResource<Node> { // this should be package 
                 return (Type) new JcrModifiableValueMap(getNode(), this.helper);
             } catch (AccessControlException ace) {
                 // the user has no write permission, cannot adapt
-                LOGGER.debug(
-                        "adaptTo(ModifiableValueMap): Cannot set properties on {}",
-                        this);
+                LOGGER.debug("adaptTo(ModifiableValueMap): Cannot set properties on {}", this);
             } catch (RepositoryException e) {
                 // some other problem, cannot adapt
-                LOGGER.debug(
-                        "adaptTo(ModifiableValueMap): Unexpected problem for {}",
-                        this);
+                LOGGER.debug("adaptTo(ModifiableValueMap): Unexpected problem for {}", this);
             }
         }
 
@@ -197,8 +205,7 @@ class JcrNodeResource extends JcrItemResource<Node> { // this should be package 
             }
 
         } catch (RepositoryException re) {
-            LOGGER.error("getInputStream: Cannot get InputStream for " + this,
-                    re);
+            LOGGER.error("getInputStream: Cannot get InputStream for " + this, re);
         }
 
         // fallback to non-streamable resource
@@ -222,12 +229,12 @@ class JcrNodeResource extends JcrItemResource<Node> { // this should be package 
     }
 
     @Override
-    @Nullable Iterator<Resource> listJcrChildren() {
+    @Nullable
+    Iterator<Resource> listJcrChildren() {
         try {
-        	NodeIterator iter = getNode().getNodes();
+            NodeIterator iter = getNode().getNodes();
             if (iter.hasNext()) {
-                return new JcrNodeResourceIterator(getResourceResolver(), path, version,
-                        iter, this.helper, null);
+                return new JcrNodeResourceIterator(getResourceResolver(), path, version, iter, this.helper, null);
             }
         } catch (final RepositoryException re) {
             LOGGER.error("listChildren: Cannot get children of " + this, re);

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrNodeResourceIterator.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrNodeResourceIterator.java
@@ -18,12 +18,12 @@
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
-import java.util.Iterator;
-import java.util.NoSuchElementException;
-
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -74,12 +74,13 @@ public class JcrNodeResourceIterator implements Iterator<Resource> {
      * @param helper the helper
      * @param excludedPaths the set of excluded paths
      */
-    public JcrNodeResourceIterator(final ResourceResolver resourceResolver,
-                                   final String parentPath,
-                                   final String parentVersion,
-                                   final NodeIterator nodes,
-                                   final HelperData helper,
-                                   final PathSet excludedPaths) {
+    public JcrNodeResourceIterator(
+            final ResourceResolver resourceResolver,
+            final String parentPath,
+            final String parentVersion,
+            final NodeIterator nodes,
+            final HelperData helper,
+            final PathSet excludedPaths) {
         this.resourceResolver = resourceResolver;
         this.parentPath = parentPath;
         this.parentVersion = parentVersion;
@@ -120,8 +121,7 @@ public class JcrNodeResourceIterator implements Iterator<Resource> {
                 final Node n = nodes.nextNode();
                 final String path = getPath(n);
                 if (this.excludedPaths.matches(path) == null) {
-                    final Resource resource = new JcrNodeResource(resourceResolver,
-                            path, parentVersion, n, helper);
+                    final Resource resource = new JcrNodeResource(resourceResolver, path, parentVersion, n, helper);
                     LOGGER.debug("seek: Returning Resource {}", resource);
                     return resource;
                 }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrNodeResourceMetadata.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrNodeResourceMetadata.java
@@ -18,6 +18,23 @@
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
+import javax.jcr.Item;
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.jcr.ValueFormatException;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.sling.api.resource.ResourceMetadata;
+import org.apache.sling.jcr.resource.internal.NodeUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static javax.jcr.Property.JCR_CONTENT;
 import static javax.jcr.Property.JCR_CREATED;
 import static javax.jcr.Property.JCR_DATA;
@@ -27,23 +44,6 @@ import static javax.jcr.Property.JCR_LAST_MODIFIED;
 import static javax.jcr.Property.JCR_MIMETYPE;
 import static javax.jcr.nodetype.NodeType.NT_FILE;
 import static javax.jcr.nodetype.NodeType.NT_FROZEN_NODE;
-
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
-
-import javax.jcr.Item;
-import javax.jcr.Node;
-import javax.jcr.Property;
-import javax.jcr.RepositoryException;
-import javax.jcr.ValueFormatException;
-
-import org.apache.sling.api.resource.ResourceMetadata;
-import org.apache.sling.jcr.resource.internal.NodeUtil;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class JcrNodeResourceMetadata extends ResourceMetadata {
 
@@ -65,10 +65,12 @@ class JcrNodeResourceMetadata extends ResourceMetadata {
     private @NotNull Node promoteNode() {
         // check stuff for nt:file nodes
         try {
-            if ((!nodePromotionChecked) &&
-                    (node.isNodeType(NT_FILE) ||
-                            (node.isNodeType(NT_FROZEN_NODE) &&
-                                    node.getProperty(JCR_FROZEN_PRIMARY_TYPE).getString().equals(NT_FILE)))) {
+            if ((!nodePromotionChecked)
+                    && (node.isNodeType(NT_FILE)
+                            || (node.isNodeType(NT_FROZEN_NODE)
+                                    && node.getProperty(JCR_FROZEN_PRIMARY_TYPE)
+                                            .getString()
+                                            .equals(NT_FILE)))) {
                 creationTime = node.getProperty(JCR_CREATED).getLong();
 
                 // continue our stuff with the jcr:content node
@@ -154,7 +156,7 @@ class JcrNodeResourceMetadata extends ResourceMetadata {
         }
         return -1;
     }
-    
+
     private long getContentLength(@NotNull Node node) {
         try {
             // if the node has a jcr:data property, use that property
@@ -182,7 +184,7 @@ class JcrNodeResourceMetadata extends ResourceMetadata {
         }
         return -1;
     }
-    
+
     private static @Nullable Item getPrimaryItem(final @NotNull Node node) throws RepositoryException {
         String name = node.getPrimaryNodeType().getPrimaryItemName();
         if (name == null) {
@@ -245,11 +247,11 @@ class JcrNodeResourceMetadata extends ResourceMetadata {
         if (super.containsKey(key)) {
             return true;
         }
-        return CREATION_TIME.equals(key) ||
-                CONTENT_TYPE.equals(key) ||
-                CHARACTER_ENCODING.equals(key) ||
-                MODIFICATION_TIME.equals(key) ||
-                CONTENT_LENGTH.equals(key);
+        return CREATION_TIME.equals(key)
+                || CONTENT_TYPE.equals(key)
+                || CHARACTER_ENCODING.equals(key)
+                || MODIFICATION_TIME.equals(key)
+                || CONTENT_LENGTH.equals(key);
     }
 
     @Override

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrPropertyResource.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrPropertyResource.java
@@ -18,11 +18,6 @@
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
-import java.io.InputStream;
-import java.math.BigDecimal;
-import java.util.Calendar;
-import java.util.Iterator;
-
 import javax.jcr.Item;
 import javax.jcr.Node;
 import javax.jcr.Property;
@@ -30,6 +25,11 @@ import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 import javax.jcr.ValueFormatException;
+
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.util.Calendar;
+import java.util.Iterator;
 
 import org.apache.sling.adapter.annotations.Adaptable;
 import org.apache.sling.adapter.annotations.Adapter;
@@ -41,11 +41,33 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Adaptable(adaptableClass = Resource.class, adapters = {
-        @Adapter(value = { Item.class, Property.class, Value.class, String.class, Boolean.class, Long.class,
-                Double.class, BigDecimal.class, Calendar.class, InputStream.class, Value[].class, String[].class,
-                Boolean[].class, Long[].class, Double[].class, BigDecimal[].class }),
-        @Adapter(value = Node.class, condition = "If the resource is a JcrPropertyResource and the property is a reference or weak reference property.") })
+@Adaptable(
+        adaptableClass = Resource.class,
+        adapters = {
+            @Adapter(
+                    value = {
+                        Item.class,
+                        Property.class,
+                        Value.class,
+                        String.class,
+                        Boolean.class,
+                        Long.class,
+                        Double.class,
+                        BigDecimal.class,
+                        Calendar.class,
+                        InputStream.class,
+                        Value[].class,
+                        String[].class,
+                        Boolean[].class,
+                        Long[].class,
+                        Double[].class,
+                        BigDecimal[].class
+                    }),
+            @Adapter(
+                    value = Node.class,
+                    condition =
+                            "If the resource is a JcrPropertyResource and the property is a reference or weak reference property.")
+        })
 class JcrPropertyResource extends JcrItemResource<Property> { // this should be package private, see SLING-1414
 
     /** default log */
@@ -53,13 +75,14 @@ class JcrPropertyResource extends JcrItemResource<Property> { // this should be 
 
     private final String resourceType;
 
-    public JcrPropertyResource(final @NotNull ResourceResolver resourceResolver,
-                               final @NotNull String path,
-                               final @Nullable String version,
-                               final @NotNull Property property) throws RepositoryException {
+    public JcrPropertyResource(
+            final @NotNull ResourceResolver resourceResolver,
+            final @NotNull String path,
+            final @Nullable String version,
+            final @NotNull Property property)
+            throws RepositoryException {
         super(resourceResolver, path, version, property, new ResourceMetadata());
-        this.resourceType = getResourceTypeForNode(property.getParent())
-                + "/" + property.getName();
+        this.resourceType = getResourceTypeForNode(property.getParent()) + "/" + property.getName();
         if (PropertyType.BINARY != getProperty().getType()) {
             this.getResourceMetadata().setContentType("text/plain");
             this.getResourceMetadata().setCharacterEncoding("UTF-8");
@@ -109,8 +132,8 @@ class JcrPropertyResource extends JcrItemResource<Property> { // this should be 
                 return (AdapterType) getProperty().getValue();
 
             } else if (type == Node.class
-                    && (getProperty().getType() == PropertyType.REFERENCE ||
-                    getProperty().getType() == PropertyType.WEAKREFERENCE)) {
+                    && (getProperty().getType() == PropertyType.REFERENCE
+                            || getProperty().getType() == PropertyType.WEAKREFERENCE)) {
                 return (AdapterType) getProperty().getNode();
 
             } else if (type == InputStream.class) {
@@ -125,7 +148,7 @@ class JcrPropertyResource extends JcrItemResource<Property> { // this should be 
                     }
                     return (AdapterType) result;
                 }
-                return (AdapterType) new String[]{getProperty().getString()};
+                return (AdapterType) new String[] {getProperty().getString()};
 
             } else if (type == Boolean[].class) {
                 if (getProperty().getDefinition().isMultiple()) {
@@ -136,7 +159,7 @@ class JcrPropertyResource extends JcrItemResource<Property> { // this should be 
                     }
                     return (AdapterType) result;
                 }
-                return (AdapterType) new Boolean[]{getProperty().getBoolean()};
+                return (AdapterType) new Boolean[] {getProperty().getBoolean()};
 
             } else if (type == Long[].class) {
                 if (getProperty().getDefinition().isMultiple()) {
@@ -147,7 +170,7 @@ class JcrPropertyResource extends JcrItemResource<Property> { // this should be 
                     }
                     return (AdapterType) result;
                 }
-                return (AdapterType) new Long[]{getProperty().getLong()};
+                return (AdapterType) new Long[] {getProperty().getLong()};
 
             } else if (type == Double[].class) {
                 if (getProperty().getDefinition().isMultiple()) {
@@ -158,7 +181,7 @@ class JcrPropertyResource extends JcrItemResource<Property> { // this should be 
                     }
                     return (AdapterType) result;
                 }
-                return (AdapterType) new Double[]{getProperty().getDouble()};
+                return (AdapterType) new Double[] {getProperty().getDouble()};
 
             } else if (type == BigDecimal[].class) {
                 if (getProperty().getDefinition().isMultiple()) {
@@ -169,7 +192,7 @@ class JcrPropertyResource extends JcrItemResource<Property> { // this should be 
                     }
                     return (AdapterType) result;
                 }
-                return (AdapterType) new BigDecimal[]{getProperty().getDecimal()};
+                return (AdapterType) new BigDecimal[] {getProperty().getDecimal()};
 
             } else if (type == Calendar[].class) {
                 if (getProperty().getDefinition().isMultiple()) {
@@ -180,14 +203,13 @@ class JcrPropertyResource extends JcrItemResource<Property> { // this should be 
                     }
                     return (AdapterType) result;
                 }
-                return (AdapterType) new Calendar[]{getProperty().getDate()};
+                return (AdapterType) new Calendar[] {getProperty().getDate()};
 
             } else if (type == Value[].class) {
                 if (getProperty().getDefinition().isMultiple()) {
                     return (AdapterType) getProperty().getValues();
                 }
-                return (AdapterType) new Value[]{getProperty().getValue()};
-
+                return (AdapterType) new Value[] {getProperty().getValue()};
             }
 
         } catch (ValueFormatException vfe) {
@@ -225,7 +247,8 @@ class JcrPropertyResource extends JcrItemResource<Property> { // this should be 
     }
 
     @Override
-    @Nullable Iterator<Resource> listJcrChildren() {
+    @Nullable
+    Iterator<Resource> listJcrChildren() {
         return null;
     }
 

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrProviderState.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrProviderState.java
@@ -18,9 +18,9 @@
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
-import java.io.Closeable;
-
 import javax.jcr.Session;
+
+import java.io.Closeable;
 
 import org.apache.sling.jcr.api.SlingRepository;
 import org.apache.sling.jcr.resource.internal.HelperData;
@@ -47,11 +47,12 @@ class JcrProviderState implements Closeable {
         this(session, helperData, logout, null, null);
     }
 
-    JcrProviderState(final @NotNull Session session,
-                     final @NotNull HelperData helperData,
-                     final boolean logout,
-                     final @Nullable BundleContext bundleContext,
-                     final @Nullable ServiceReference<SlingRepository> repositoryRef) {
+    JcrProviderState(
+            final @NotNull Session session,
+            final @NotNull HelperData helperData,
+            final boolean logout,
+            final @Nullable BundleContext bundleContext,
+            final @Nullable ServiceReference<SlingRepository> repositoryRef) {
         this.session = session;
         this.bundleContext = bundleContext;
         this.repositoryRef = repositoryRef;
@@ -60,15 +61,18 @@ class JcrProviderState implements Closeable {
         this.resourceFactory = new JcrItemResourceFactory(session, helperData);
     }
 
-    @NotNull Session getSession() {
+    @NotNull
+    Session getSession() {
         return session;
     }
 
-    @NotNull JcrItemResourceFactory getResourceFactory() {
+    @NotNull
+    JcrItemResourceFactory getResourceFactory() {
         return resourceFactory;
     }
 
-    @NotNull HelperData getHelperData() {
+    @NotNull
+    HelperData getHelperData() {
         return helperData;
     }
 

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrProviderStateFactory.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrProviderStateFactory.java
@@ -18,13 +18,13 @@
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
-
 import javax.jcr.Credentials;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.SimpleCredentials;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -56,10 +56,11 @@ public class JcrProviderStateFactory {
     private final AtomicReference<DynamicClassLoaderManager> dynamicClassLoaderManagerReference;
     private final AtomicReference<URIProvider[]> uriProviderReference;
 
-    public JcrProviderStateFactory(final ServiceReference<SlingRepository> repositoryReference,
-                                   final SlingRepository repository,
-                                   final AtomicReference<DynamicClassLoaderManager> dynamicClassLoaderManagerReference,
-                                   final AtomicReference<URIProvider[]> uriProviderReference) {
+    public JcrProviderStateFactory(
+            final ServiceReference<SlingRepository> repositoryReference,
+            final SlingRepository repository,
+            final AtomicReference<DynamicClassLoaderManager> dynamicClassLoaderManagerReference,
+            final AtomicReference<URIProvider[]> uriProviderReference) {
         this.repository = repository;
         this.repositoryReference = repositoryReference;
         this.dynamicClassLoaderManagerReference = dynamicClassLoaderManagerReference;
@@ -79,7 +80,8 @@ public class JcrProviderStateFactory {
     }
 
     @SuppressWarnings("deprecation")
-    @NotNull JcrProviderState createProviderState(final @NotNull Map<String, Object> authenticationInfo) throws LoginException {
+    @NotNull
+    JcrProviderState createProviderState(final @NotNull Map<String, Object> authenticationInfo) throws LoginException {
         boolean isLoginAdministrative = Boolean.TRUE.equals(authenticationInfo.get(ResourceProvider.AUTH_ADMIN));
 
         // check whether a session is provided in the authenticationInfo
@@ -98,7 +100,8 @@ public class JcrProviderStateFactory {
                 bc = bundle.getBundleContext();
                 final SlingRepository repo = bc == null ? null : bc.getService(repositoryReference);
                 if (repo == null) {
-                    logger.warn("Cannot login {} because cannot get SlingRepository on behalf of bundle {} ({})",
+                    logger.warn(
+                            "Cannot login {} because cannot get SlingRepository on behalf of bundle {} ({})",
                             isLoginAdministrative ? "admin" : "service",
                             bundle.getSymbolicName(),
                             bundle.getBundleId());
@@ -120,15 +123,15 @@ public class JcrProviderStateFactory {
                             // ResourceResolver provides it when a session was impersonated; in the actual
                             // implementation it will be retrieved from the session when calling {@link
                             // ResourceResolver#getAttribute(String)} with {@link ResourceResolver#USER_IMPERSONATOR}
-                            creds.setAttribute(ResourceResolver.USER_IMPERSONATOR, subServiceName == null ?
-                                    bundle.getSymbolicName() : subServiceName);
+                            creds.setAttribute(
+                                    ResourceResolver.USER_IMPERSONATOR,
+                                    subServiceName == null ? bundle.getSymbolicName() : subServiceName);
                             session = repo.impersonateFromService(subServiceName, creds, null);
                             // if the impersonation worked we should have a session now; let's remove the sudo user
                             // from the authentication info to skip the impersonation logic below
                             authenticationInfo.remove(ResourceResolverFactory.USER_IMPERSONATION);
                         } else {
                             session = repo.loginService(subServiceName, null);
-
                         }
                     }
                 } catch (Throwable t) {
@@ -155,11 +158,15 @@ public class JcrProviderStateFactory {
         return createJcrProviderState(session, true, authenticationInfo, bc);
     }
 
-    private @NotNull JcrProviderState createJcrProviderState(@NotNull final Session session, final boolean logoutSession,
-                                                             @NotNull final Map<String, Object> authenticationInfo,
-                                                             @Nullable final BundleContext ctx) throws LoginException {
+    private @NotNull JcrProviderState createJcrProviderState(
+            @NotNull final Session session,
+            final boolean logoutSession,
+            @NotNull final Map<String, Object> authenticationInfo,
+            @Nullable final BundleContext ctx)
+            throws LoginException {
         boolean explicitSessionUsed = (getSession(authenticationInfo) != null);
-        final Session impersonatedSession = handleImpersonation(session, authenticationInfo, logoutSession, explicitSessionUsed);
+        final Session impersonatedSession =
+                handleImpersonation(session, authenticationInfo, logoutSession, explicitSessionUsed);
         if (impersonatedSession != session && explicitSessionUsed) {
             // update the session in the auth info map in case the resolver gets cloned in the future
             authenticationInfo.put(JcrResourceConstants.AUTHENTICATION_INFO_SESSION, impersonatedSession);
@@ -168,7 +175,8 @@ public class JcrProviderStateFactory {
         // of what the original logoutSession value was.
         boolean doLogoutSession = logoutSession || (impersonatedSession != session);
         final HelperData data = new HelperData(this.dynamicClassLoaderManagerReference, this.uriProviderReference);
-        return new JcrProviderState(impersonatedSession, data, doLogoutSession, ctx, ctx == null ? null : repositoryReference);
+        return new JcrProviderState(
+                impersonatedSession, data, doLogoutSession, ctx, ctx == null ? null : repositoryReference);
     }
 
     /**
@@ -191,15 +199,21 @@ public class JcrProviderStateFactory {
      * @throws LoginException
      *             If something goes wrong.
      */
-    private static Session handleImpersonation(final Session session, final Map<String, Object> authenticationInfo,
-                                               final boolean logoutSession, boolean explicitSessionUsed) throws LoginException {
+    private static Session handleImpersonation(
+            final Session session,
+            final Map<String, Object> authenticationInfo,
+            final boolean logoutSession,
+            boolean explicitSessionUsed)
+            throws LoginException {
         final String sudoUser = getSudoUser(authenticationInfo);
         // Do we need session.impersonate() because we are asked to impersonate another user?
         boolean needsSudo = (sudoUser != null) && !session.getUserID().equals(sudoUser);
         // Do we need session.impersonate() to get an independent copy of the session we were given in the auth info?
-        boolean needsCloning = !needsSudo && explicitSessionUsed && authenticationInfo.containsKey(ResourceProvider.AUTH_CLONE);
+        boolean needsCloning =
+                !needsSudo && explicitSessionUsed && authenticationInfo.containsKey(ResourceProvider.AUTH_CLONE);
         if (!needsSudo && !needsCloning) {
-            // Nothing to do, but we need to make sure not to enter the try-finally below because it could close the session.
+            // Nothing to do, but we need to make sure not to enter the try-finally below because it could close the
+            // session.
             return session;
         }
         try {
@@ -258,8 +272,8 @@ public class JcrProviderStateFactory {
         Credentials creds = null;
         if (authenticationInfo != null) {
 
-            final Object credentialsObject = authenticationInfo
-                    .get(JcrResourceConstants.AUTHENTICATION_INFO_CREDENTIALS);
+            final Object credentialsObject =
+                    authenticationInfo.get(JcrResourceConstants.AUTHENTICATION_INFO_CREDENTIALS);
 
             if (credentialsObject instanceof Credentials) {
                 creds = (Credentials) credentialsObject;
@@ -269,8 +283,8 @@ public class JcrProviderStateFactory {
                 final Object userId = authenticationInfo.get(ResourceResolverFactory.USER);
                 if (userId instanceof String) {
                     final Object password = authenticationInfo.get(ResourceResolverFactory.PASSWORD);
-                    final SimpleCredentials credentials = new SimpleCredentials((String) userId,
-                            ((password instanceof char[]) ? (char[]) password : new char[0]));
+                    final SimpleCredentials credentials = new SimpleCredentials(
+                            (String) userId, ((password instanceof char[]) ? (char[]) password : new char[0]));
 
                     // add attributes
                     copyAttributes(credentials, authenticationInfo);
@@ -358,5 +372,4 @@ public class JcrProviderStateFactory {
         }
         return null;
     }
-
 }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProvider.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProvider.java
@@ -18,6 +18,12 @@
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
+import javax.jcr.Item;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.security.Principal;
@@ -31,12 +37,6 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
-
-import javax.jcr.Item;
-import javax.jcr.Node;
-import javax.jcr.NodeIterator;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.api.JackrabbitSession;
@@ -85,26 +85,39 @@ import static org.apache.sling.jcr.resource.internal.helper.jcr.ContextUtil.getH
 import static org.apache.sling.jcr.resource.internal.helper.jcr.ContextUtil.getResourceFactory;
 import static org.apache.sling.jcr.resource.internal.helper.jcr.ContextUtil.getSession;
 
-@Adaptable(adaptableClass = ResourceProvider.class, adapters = { @Adapter(value=Session.class, condition="If the JcrResourceProvider is loaded"), @Adapter(value=Principal.class, condition="If the underlying java.jcr.Session implements JackrabbitSession") })
-@Component(name="org.apache.sling.jcr.resource.internal.helper.jcr.JcrResourceProviderFactory",
-           service = ResourceProvider.class,
-           property = {
-                   ResourceProvider.PROPERTY_NAME + "=JCR",
-                   ResourceProvider.PROPERTY_ROOT + "=/",
-                   ResourceProvider.PROPERTY_MODIFIABLE + ":Boolean=true",
-                   ResourceProvider.PROPERTY_ADAPTABLE + ":Boolean=true",
-                   ResourceProvider.PROPERTY_ATTRIBUTABLE + ":Boolean=true",
-                   ResourceProvider.PROPERTY_REFRESHABLE + ":Boolean=true",
-                   ResourceProvider.PROPERTY_AUTHENTICATE + "=" + ResourceProvider.AUTHENTICATE_REQUIRED,
-                   Constants.SERVICE_VENDOR + "=The Apache Software Foundation"
-           })
-@Designate(
-        ocd = JcrResourceProvider.Configuration.class
-)
+@Adaptable(
+        adaptableClass = ResourceProvider.class,
+        adapters = {
+            @Adapter(value = Session.class, condition = "If the JcrResourceProvider is loaded"),
+            @Adapter(
+                    value = Principal.class,
+                    condition = "If the underlying java.jcr.Session implements JackrabbitSession")
+        })
+@Component(
+        name = "org.apache.sling.jcr.resource.internal.helper.jcr.JcrResourceProviderFactory",
+        service = ResourceProvider.class,
+        property = {
+            ResourceProvider.PROPERTY_NAME + "=JCR",
+            ResourceProvider.PROPERTY_ROOT + "=/",
+            ResourceProvider.PROPERTY_MODIFIABLE + ":Boolean=true",
+            ResourceProvider.PROPERTY_ADAPTABLE + ":Boolean=true",
+            ResourceProvider.PROPERTY_ATTRIBUTABLE + ":Boolean=true",
+            ResourceProvider.PROPERTY_REFRESHABLE + ":Boolean=true",
+            ResourceProvider.PROPERTY_AUTHENTICATE + "=" + ResourceProvider.AUTHENTICATE_REQUIRED,
+            Constants.SERVICE_VENDOR + "=The Apache Software Foundation"
+        })
+@Designate(ocd = JcrResourceProvider.Configuration.class)
 public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
 
     // due to https://issues.apache.org/jira/browse/SLING-11517 a dedicated class is necessary
-    @Adaptable(adaptableClass = ResourceResolver.class, adapters = { @Adapter(value=Session.class, condition="If the JcrResourceProvider is loaded"), @Adapter(value=Principal.class, condition="If the underlying java.jcr.Session implements JackrabbitSession") })
+    @Adaptable(
+            adaptableClass = ResourceResolver.class,
+            adapters = {
+                @Adapter(value = Session.class, condition = "If the JcrResourceProvider is loaded"),
+                @Adapter(
+                        value = Principal.class,
+                        condition = "If the underlying java.jcr.Session implements JackrabbitSession")
+            })
     private static final class EmptyAdaptableAnnotationCarryingClass {
         // just to carry the annotation
     }
@@ -114,6 +127,7 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
     private static final String REPOSITORY_REFERENCE_NAME = "repository";
 
     private static final Set<String> IGNORED_PROPERTIES = new HashSet<>();
+
     static {
         IGNORED_PROPERTIES.add(JcrConstants.JCR_MIXINTYPES);
         IGNORED_PROPERTIES.add(JcrConstants.JCR_PRIMARYTYPE);
@@ -134,7 +148,8 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
      * Map of bound URIProviders sorted by service ranking in descending order (highest ranking first).
      * Key = service reference, value = service implementation
      */
-    private final SortedMap<ServiceReference<URIProvider>, URIProvider> providers = Collections.synchronizedSortedMap(new TreeMap<>(Collections.reverseOrder()));
+    private final SortedMap<ServiceReference<URIProvider>, URIProvider> providers =
+            Collections.synchronizedSortedMap(new TreeMap<>(Collections.reverseOrder()));
 
     private volatile SlingRepository repository;
 
@@ -148,24 +163,19 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
 
     @ObjectClassDefinition(
             name = "Apache Sling JCR Resource Provider",
-            description = "The JCR Resource Provider provides access to the JCR repository."
-
-    )
+            description = "The JCR Resource Provider provides access to the JCR repository.")
     @interface Configuration {
 
         @AttributeDefinition(
                 name = "Resource Addressing by ID",
-                description = "If enabled, the resource provider will enable addressing resources by their JCR UUID " +
-                        "by using the special path prefix '/jcr:id/'."
-        )
+                description = "If enabled, the resource provider will enable addressing resources by their JCR UUID "
+                        + "by using the special path prefix '/jcr:id/'.")
         boolean resource_addressingById() default false;
-
     }
 
     @Activate
     protected void activate(final ComponentContext context, final Configuration configuration) {
-        SlingRepository slingRepository = context.locateService(REPOSITORY_REFERENCE_NAME,
-                this.repositoryReference);
+        SlingRepository slingRepository = context.locateService(REPOSITORY_REFERENCE_NAME, this.repositoryReference);
         if (slingRepository == null) {
             // concurrent unregistration of SlingRepository service
             // don't care, this component is going to be deactivated
@@ -176,8 +186,8 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
 
         this.repository = slingRepository;
 
-        this.stateFactory = new JcrProviderStateFactory(repositoryReference, slingRepository,
-                classLoaderManagerReference, uriProviderReference);
+        this.stateFactory = new JcrProviderStateFactory(
+                repositoryReference, slingRepository, classLoaderManagerReference, uriProviderReference);
 
         idAddressing = configuration.resource_addressingById();
     }
@@ -187,14 +197,16 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
         this.stateFactory = null;
     }
 
-    @Reference(name = "dynamicClassLoaderManager",
+    @Reference(
+            name = "dynamicClassLoaderManager",
             service = DynamicClassLoaderManager.class,
-            cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
+            cardinality = ReferenceCardinality.OPTIONAL,
+            policy = ReferencePolicy.DYNAMIC)
     @SuppressWarnings("unused")
     protected void bindDynamicClassLoaderManager(final DynamicClassLoaderManager dynamicClassLoaderManager) {
         this.classLoaderManagerReference.set(dynamicClassLoaderManager);
     }
-    
+
     @SuppressWarnings("unused")
     protected void unbindDynamicClassLoaderManager(final DynamicClassLoaderManager dynamicClassLoaderManager) {
         this.classLoaderManagerReference.compareAndSet(dynamicClassLoaderManager, null);
@@ -206,8 +218,7 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
             cardinality = ReferenceCardinality.MULTIPLE,
             policy = ReferencePolicy.DYNAMIC,
             bind = "bindUriProvider",
-            unbind = "unbindUriProvider"
-    )
+            unbind = "unbindUriProvider")
     @SuppressWarnings("unused")
     private void bindUriProvider(ServiceReference<URIProvider> srUriProvider, URIProvider uriProvider) {
         providers.put(srUriProvider, uriProvider);
@@ -272,9 +283,10 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
         if (this.repository != null) {
             logger.debug("Registering resource listeners...");
             try {
-                this.listenerConfig = new JcrListenerBaseConfig(this.getProviderContext().getObservationReporter(),
-                        this.repository);
-                for (final ObserverConfiguration config : this.getProviderContext().getObservationReporter().getObserverConfigurations()) {
+                this.listenerConfig =
+                        new JcrListenerBaseConfig(this.getProviderContext().getObservationReporter(), this.repository);
+                for (final ObserverConfiguration config :
+                        this.getProviderContext().getObservationReporter().getObserverConfigurations()) {
                     logger.debug("Registering listener for {}", config.getPaths());
                     final Closeable listener = new JcrResourceListener(this.listenerConfig, config);
                     this.listeners.put(config, listener);
@@ -293,7 +305,9 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
         logger.debug("Unregistering resource listeners...");
         for (final Closeable c : this.listeners.values()) {
             try {
-                logger.debug("Removing listener for {}", ((JcrResourceListener) c).getConfig().getPaths());
+                logger.debug(
+                        "Removing listener for {}",
+                        ((JcrResourceListener) c).getConfig().getPaths());
                 c.close();
             } catch (final IOException e) {
                 // ignore this as the method above does not throw it
@@ -319,7 +333,8 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
             final Map<ObserverConfiguration, Closeable> oldMap = new HashMap<>(this.listeners);
             this.listeners.clear();
             try {
-                for (final ObserverConfiguration config : this.getProviderContext().getObservationReporter().getObserverConfigurations()) {
+                for (final ObserverConfiguration config :
+                        this.getProviderContext().getObservationReporter().getObserverConfigurations()) {
                     // check if such a listener already exists
                     Closeable listener = oldMap.remove(config);
                     if (listener == null) {
@@ -336,7 +351,9 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
             }
             for (final Closeable c : oldMap.values()) {
                 try {
-                    logger.debug("Removing listener for {}", ((JcrResourceListener) c).getConfig().getPaths());
+                    logger.debug(
+                            "Removing listener for {}",
+                            ((JcrResourceListener) c).getConfig().getPaths());
                     c.close();
                 } catch (final IOException e) {
                     // ignore this as the method above does not throw it
@@ -370,10 +387,14 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
 
     @Override
     @Nullable
-    public Resource getResource(@NotNull ResolveContext<JcrProviderState> ctx, @NotNull String path, 
-                                @NotNull ResourceContext rCtx, @Nullable Resource parent) {
+    public Resource getResource(
+            @NotNull ResolveContext<JcrProviderState> ctx,
+            @NotNull String path,
+            @NotNull ResourceContext rCtx,
+            @Nullable Resource parent) {
         try {
-            return getResourceFactory(ctx).createResource(ctx.getResourceResolver(), path, parent, rCtx.getResolveParameters());
+            return getResourceFactory(ctx)
+                    .createResource(ctx.getResourceResolver(), path, parent, rCtx.getResolveParameters());
         } catch (RepositoryException e) {
             throw new SlingException("Can't get resource", e);
         }
@@ -391,22 +412,24 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
             // try to get the JcrItemResource for the parent path to list
             // children
             try {
-                parentItemResource = getResourceFactory(ctx).createResource(
-                        parent.getResourceResolver(), parent.getPath(), null,
-                        parent.getResourceMetadata().getParameterMap());
+                parentItemResource = getResourceFactory(ctx)
+                        .createResource(
+                                parent.getResourceResolver(),
+                                parent.getPath(),
+                                null,
+                                parent.getResourceMetadata().getParameterMap());
             } catch (RepositoryException re) {
                 throw new SlingException("Can't list children", re);
             }
         }
 
         // return children if there is a parent item resource, else null
-        return (parentItemResource != null)
-                ? parentItemResource.listJcrChildren()
-                : null;
+        return (parentItemResource != null) ? parentItemResource.listJcrChildren() : null;
     }
 
     @Override
-    public @Nullable Resource getParent(final @NotNull ResolveContext<JcrProviderState> ctx, final @NotNull Resource child) {
+    public @Nullable Resource getParent(
+            final @NotNull ResolveContext<JcrProviderState> ctx, final @NotNull Resource child) {
         if (child instanceof JcrItemResource<?>) {
             String version = null;
             if (child.getResourceMetadata().getParameterMap() != null) {
@@ -418,7 +441,8 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
                     Item childItem = ((JcrItemResource) child).getItem();
                     Node parentNode = getResourceFactory(ctx).getParentOrNull(childItem, parentPath);
                     if (parentNode != null) {
-                        return new JcrNodeResource(ctx.getResourceResolver(), parentPath, null, parentNode, getHelperData(ctx));
+                        return new JcrNodeResource(
+                                ctx.getResourceResolver(), parentPath, null, parentNode, getHelperData(ctx));
                     }
                 }
             }
@@ -454,8 +478,11 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
 
     @Override
     @NotNull
-    public Resource create(final @NotNull ResolveContext<JcrProviderState> ctx, @Nullable final String path,
-            @Nullable final Map<String, Object> properties) throws PersistenceException {
+    public Resource create(
+            final @NotNull ResolveContext<JcrProviderState> ctx,
+            @Nullable final String path,
+            @Nullable final Map<String, Object> properties)
+            throws PersistenceException {
 
         if (path == null) {
             throw new PersistenceException("Unable to create node with [path=null]");
@@ -487,9 +514,9 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
             throw new PersistenceException("Unable to create node at " + path, e, path, null);
         }
     }
-    
-    protected static @Nullable String getNodeType(@Nullable Map<String, Object> properties,
-            @NotNull ResolveContext<JcrProviderState> ctx) {
+
+    protected static @Nullable String getNodeType(
+            @Nullable Map<String, Object> properties, @NotNull ResolveContext<JcrProviderState> ctx) {
         if (properties == null) {
             return null;
         }
@@ -514,12 +541,17 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
         }
         return null;
     }
-    
+
     private static boolean looksLikeANodeType(final String resourceType) {
         return resourceType.indexOf(':') != -1 && resourceType.indexOf('/') == -1;
     }
 
-    private static void populateProperties(@NotNull Node node, @NotNull Map<String, Object> properties, @NotNull ResolveContext<JcrProviderState> ctx, @NotNull String path) throws PersistenceException {
+    private static void populateProperties(
+            @NotNull Node node,
+            @NotNull Map<String, Object> properties,
+            @NotNull ResolveContext<JcrProviderState> ctx,
+            @NotNull String path)
+            throws PersistenceException {
         // create modifiable map
         final JcrModifiableValueMap jcrMap = new JcrModifiableValueMap(node, getHelperData(ctx));
         // check mixin types first
@@ -544,11 +576,16 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
     }
 
     @Override
-    public boolean orderBefore(@NotNull ResolveContext<JcrProviderState> ctx, @NotNull Resource parent, @NotNull String name,
-                               @Nullable String followingSiblingName) throws PersistenceException {
+    public boolean orderBefore(
+            @NotNull ResolveContext<JcrProviderState> ctx,
+            @NotNull Resource parent,
+            @NotNull String name,
+            @Nullable String followingSiblingName)
+            throws PersistenceException {
         Node node = parent.adaptTo(Node.class);
         if (node == null) {
-            throw new PersistenceException("The resource " + parent.getPath() + " cannot be adapted to Node. It is probably not provided by the JcrResourceProvider");
+            throw new PersistenceException("The resource " + parent.getPath()
+                    + " cannot be adapted to Node. It is probably not provided by the JcrResourceProvider");
         }
         try {
             // check if reordering necessary
@@ -558,11 +595,14 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
             }
             return false;
         } catch (final RepositoryException e) {
-            throw new PersistenceException("Unable to reorder children below " + parent.getPath(), e, parent.getPath(), null);
+            throw new PersistenceException(
+                    "Unable to reorder children below " + parent.getPath(), e, parent.getPath(), null);
         }
     }
-    
-    private static boolean requiresReorder(@NotNull Node node, @NotNull String name, @Nullable String followingSiblingName) throws RepositoryException {
+
+    private static boolean requiresReorder(
+            @NotNull Node node, @NotNull String name, @Nullable String followingSiblingName)
+            throws RepositoryException {
         NodeIterator nodeIterator = node.getNodes();
         long existingNodePosition = -1;
         long index = 0;
@@ -589,7 +629,8 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
     }
 
     @Override
-    public void delete(final @NotNull ResolveContext<JcrProviderState> ctx, final @NotNull Resource resource) throws PersistenceException {
+    public void delete(final @NotNull ResolveContext<JcrProviderState> ctx, final @NotNull Resource resource)
+            throws PersistenceException {
         // try to adapt to Item
         Item item = resource.adaptTo(Item.class);
         try {
@@ -641,8 +682,8 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
 
     @SuppressWarnings("unchecked")
     @Override
-    public @Nullable <AdapterType> AdapterType adaptTo(final @NotNull ResolveContext<JcrProviderState> ctx,
-                                                       final @NotNull Class<AdapterType> type) {
+    public @Nullable <AdapterType> AdapterType adaptTo(
+            final @NotNull ResolveContext<JcrProviderState> ctx, final @NotNull Class<AdapterType> type) {
         Session session = getSession(ctx);
         if (type == Session.class) {
             return (AdapterType) session;
@@ -667,16 +708,19 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
     }
 
     @Override
-    public boolean copy(final @NotNull ResolveContext<JcrProviderState> ctx,
-                        final @NotNull String srcAbsPath,
-                        final @NotNull String destAbsPath) {
+    public boolean copy(
+            final @NotNull ResolveContext<JcrProviderState> ctx,
+            final @NotNull String srcAbsPath,
+            final @NotNull String destAbsPath) {
         return false;
     }
 
     @Override
-    public boolean move(final @NotNull ResolveContext<JcrProviderState> ctx,
-                        final @NotNull String srcAbsPath,
-                        final @NotNull String destAbsPath) throws PersistenceException {
+    public boolean move(
+            final @NotNull ResolveContext<JcrProviderState> ctx,
+            final @NotNull String srcAbsPath,
+            final @NotNull String destAbsPath)
+            throws PersistenceException {
         final String srcNodePath = srcAbsPath;
         final String dstNodePath = destAbsPath + '/' + ResourceUtil.getName(srcAbsPath);
         try {
@@ -708,7 +752,6 @@ public class JcrResourceProvider extends ResourceProvider<JcrProviderState> {
      * @throws NullPointerException if <code>name</code> is <code>null</code>
      */
     private static boolean isAttributeVisible(final String name) {
-        return !name.equals(JcrResourceConstants.AUTHENTICATION_INFO_CREDENTIALS)
-                && !name.contains("password");
+        return !name.equals(JcrResourceConstants.AUTHENTICATION_INFO_CREDENTIALS) && !name.contains("password");
     }
 }

--- a/src/main/java/org/apache/sling/jcr/resource/internal/scripting/JcrObjectsBindingsValuesProvider.java
+++ b/src/main/java/org/apache/sling/jcr/resource/internal/scripting/JcrObjectsBindingsValuesProvider.java
@@ -1,18 +1,20 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with this
- * work for additional information regarding copyright ownership. The ASF
- * licenses this file to You under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.sling.jcr.resource.internal.scripting;
 
@@ -28,11 +30,12 @@ import org.osgi.service.component.annotations.Component;
 /**
  * BindingsValuesProvider for currentNode and currentSession object.
  */
-@Component(service = BindingsValuesProvider.class,
-           property = {
-                   Constants.SERVICE_DESCRIPTION + "=Apache Sling CurrentNode BindingsValuesProvider",
-                   Constants.SERVICE_VENDOR + "=The Apache Software Foundation"
-           })
+@Component(
+        service = BindingsValuesProvider.class,
+        property = {
+            Constants.SERVICE_DESCRIPTION + "=Apache Sling CurrentNode BindingsValuesProvider",
+            Constants.SERVICE_VENDOR + "=The Apache Software Foundation"
+        })
 public class JcrObjectsBindingsValuesProvider implements BindingsValuesProvider {
 
     private static final String PROP_CURRENT_NODE = "currentNode";
@@ -50,8 +53,7 @@ public class JcrObjectsBindingsValuesProvider implements BindingsValuesProvider 
                 bindings.put(PROP_CURRENT_NODE, node);
             }
             if (bindings.get(PROP_CURRENT_SESSION) == null) {
-                final Session session = resource.getResourceResolver().adaptTo(
-                        Session.class);
+                final Session session = resource.getResourceResolver().adaptTo(Session.class);
                 if (session != null) {
                     bindings.put(PROP_CURRENT_SESSION, session);
                 }

--- a/src/test/java/org/apache/sling/jcr/resource/internal/AssertCalendar.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/AssertCalendar.java
@@ -1,24 +1,26 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with this
- * work for additional information regarding copyright ownership. The ASF
- * licenses this file to You under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.sling.jcr.resource.internal;
 
-import org.junit.Assert;
-
 import java.util.Calendar;
+
+import org.junit.Assert;
 
 public final class AssertCalendar {
 
@@ -37,5 +39,4 @@ public final class AssertCalendar {
             Assert.assertEquals(expected.getTimeInMillis(), actual.getTimeInMillis());
         }
     }
-
 }

--- a/src/test/java/org/apache/sling/jcr/resource/internal/JcrListenerBaseConfigTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/JcrListenerBaseConfigTest.java
@@ -18,11 +18,6 @@
  */
 package org.apache.sling.jcr.resource.internal;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import org.apache.jackrabbit.oak.jcr.observation.filter.OakEventFilter;
 import org.apache.sling.api.resource.path.Path;
 import org.apache.sling.api.resource.path.PathSet;
@@ -30,6 +25,10 @@ import org.apache.sling.spi.resource.provider.ObserverConfiguration;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class JcrListenerBaseConfigTest {
 
@@ -40,14 +39,13 @@ public class JcrListenerBaseConfigTest {
         Path globbed = new Path("glob:/globbed/path");
         Path nonglobbed = new Path("/nonglobbed/path");
         ObserverConfiguration config = mock(ObserverConfiguration.class);
-        when(config.getPaths()).thenReturn(PathSet.fromPaths(globbed,nonglobbed));
+        when(config.getPaths()).thenReturn(PathSet.fromPaths(globbed, nonglobbed));
 
         JcrListenerBaseConfig.setFilterPaths(filter, config);
 
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(filter).setAdditionalPaths(pathCaptor.capture());
         assertEquals("/nonglobbed/path", pathCaptor.getValue());
-
 
         ArgumentCaptor<String> globPathCaptor = ArgumentCaptor.forClass(String.class);
         verify(filter).withIncludeGlobPaths(globPathCaptor.capture());

--- a/src/test/java/org/apache/sling/jcr/resource/internal/JcrModifiableValueMapTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/JcrModifiableValueMapTest.java
@@ -18,7 +18,12 @@
  */
 package org.apache.sling.jcr.resource.internal;
 
-import static org.apache.sling.jcr.resource.internal.AssertCalendar.assertEqualsCalendar;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Value;
+import javax.jcr.ValueFactory;
+import javax.jcr.nodetype.NodeType;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -40,19 +45,14 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.jcr.Node;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import javax.jcr.Value;
-import javax.jcr.ValueFactory;
-import javax.jcr.nodetype.NodeType;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.jackrabbit.util.Text;
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.jcr.resource.internal.helper.jcr.SlingRepositoryTestBase;
+
+import static org.apache.sling.jcr.resource.internal.AssertCalendar.assertEqualsCalendar;
 
 public class JcrModifiableValueMapTest extends SlingRepositoryTestBase {
 
@@ -65,8 +65,7 @@ public class JcrModifiableValueMapTest extends SlingRepositoryTestBase {
     protected void setUp() throws Exception {
         super.setUp();
         String rootPath = "/test_" + System.currentTimeMillis();
-        rootNode = getSession().getRootNode().addNode(rootPath.substring(1),
-                "nt:unstructured");
+        rootNode = getSession().getRootNode().addNode(rootPath.substring(1), "nt:unstructured");
 
         final Map<String, Object> values = this.initialSet();
         for (Map.Entry<String, Object> entry : values.entrySet()) {
@@ -75,9 +74,7 @@ public class JcrModifiableValueMapTest extends SlingRepositoryTestBase {
         getSession().save();
     }
 
-    private void setProperty(final Node node,
-                             final String propertyName,
-                             final Object propertyValue)
+    private void setProperty(final Node node, final String propertyName, final Object propertyValue)
             throws RepositoryException {
         if (propertyValue == null) {
             node.setProperty(propertyName, (String) null);
@@ -94,8 +91,7 @@ public class JcrModifiableValueMapTest extends SlingRepositoryTestBase {
         }
     }
 
-    Value createValue(final Object value, final Session session)
-            throws RepositoryException {
+    Value createValue(final Object value, final Session session) throws RepositoryException {
         Value val;
         ValueFactory fac = session.getValueFactory();
         if (value instanceof Calendar) {
@@ -151,11 +147,13 @@ public class JcrModifiableValueMapTest extends SlingRepositoryTestBase {
         pvm.put("binary", stream);
         getSession().save();
         final ValueMap valueMap2 = new JcrValueMap(this.rootNode, getHelperData());
-        assertEquals("The read stream is not what we wrote.", IOUtils.toString(valueMap2.get("binary", InputStream.class)), TEST_BYTE_ARRAY_TO_STRING);
+        assertEquals(
+                "The read stream is not what we wrote.",
+                IOUtils.toString(valueMap2.get("binary", InputStream.class)),
+                TEST_BYTE_ARRAY_TO_STRING);
     }
 
-    public void testPut()
-            throws Exception {
+    public void testPut() throws Exception {
         getSession().refresh(false);
         final ModifiableValueMap pvm = new JcrModifiableValueMap(this.rootNode, getHelperData());
         assertContains(pvm, initialSet());
@@ -177,8 +175,7 @@ public class JcrModifiableValueMapTest extends SlingRepositoryTestBase {
         assertContains(pvm2, currentlyStored);
     }
 
-    public void testRemove()
-            throws Exception {
+    public void testRemove() throws Exception {
         getSession().refresh(false);
         final ModifiableValueMap pvm = new JcrModifiableValueMap(this.rootNode, getHelperData());
 
@@ -193,8 +190,7 @@ public class JcrModifiableValueMapTest extends SlingRepositoryTestBase {
         assertFalse(pvm.containsKey(key));
     }
 
-    public void testSerializable()
-            throws Exception {
+    public void testSerializable() throws Exception {
         this.rootNode.getSession().refresh(false);
         final ModifiableValueMap pvm = new JcrModifiableValueMap(this.rootNode, getHelperData());
         assertContains(pvm, initialSet());
@@ -207,16 +203,17 @@ public class JcrModifiableValueMapTest extends SlingRepositoryTestBase {
         pvm.put("something", strings);
 
         // check if we get the list again
-        @SuppressWarnings("unchecked") final List<String> strings2 = (List<String>) pvm.get("something");
+        @SuppressWarnings("unchecked")
+        final List<String> strings2 = (List<String>) pvm.get("something");
         assertEquals(strings, strings2);
 
         getSession().save();
 
         final ValueMap pvm2 = new JcrValueMap(this.rootNode, getHelperData());
         // check if we get the list again
-        @SuppressWarnings("unchecked") final List<String> strings3 = (List<String>) pvm2.get("something", Serializable.class);
+        @SuppressWarnings("unchecked")
+        final List<String> strings3 = (List<String>) pvm2.get("something", Serializable.class);
         assertEquals(strings, strings3);
-
     }
 
     public void testExceptions() throws Exception {
@@ -242,7 +239,9 @@ public class JcrModifiableValueMapTest extends SlingRepositoryTestBase {
             pvm.put("something", new TestClass("somevalue"));
             fail("Put with class not serializable at run time");
         } catch (IllegalArgumentException iae) {
-            assertEquals(NotSerializableException.class, ExceptionUtils.getRootCause(iae).getClass());
+            assertEquals(
+                    NotSerializableException.class,
+                    ExceptionUtils.getRootCause(iae).getClass());
         }
     }
 
@@ -253,7 +252,6 @@ public class JcrModifiableValueMapTest extends SlingRepositoryTestBase {
         public TestClass(final String name) {
             this.name = Optional.of(name);
         }
-
     }
 
     private Set<String> getMixinNodeTypes(final Node node) throws RepositoryException {
@@ -333,8 +331,7 @@ public class JcrModifiableValueMapTest extends SlingRepositoryTestBase {
     public void testNamesUpdate() throws Exception {
         this.rootNode.getSession().refresh(false);
 
-        final Node testNode = this.rootNode.addNode("nameUpdateTest"
-                + System.currentTimeMillis());
+        final Node testNode = this.rootNode.addNode("nameUpdateTest" + System.currentTimeMillis());
         testNode.setProperty(PROP3, VALUE);
         testNode.getSession().save();
 
@@ -352,8 +349,11 @@ public class JcrModifiableValueMapTest extends SlingRepositoryTestBase {
 
         // read properties
         assertEquals(VALUE3, testNode.getProperty(PROP3).getString());
-        assertEquals(VALUE3, testNode.getProperty("jcr:" + Text.escapeIllegalJcrChars("a:b")).getString());
-        assertEquals(VALUE3, testNode.getProperty(Text.escapeIllegalJcrChars("jcr:")).getString());
+        assertEquals(
+                VALUE3,
+                testNode.getProperty("jcr:" + Text.escapeIllegalJcrChars("a:b")).getString());
+        assertEquals(
+                VALUE3, testNode.getProperty(Text.escapeIllegalJcrChars("jcr:")).getString());
         assertFalse(testNode.hasProperty(Text.escapeIllegalJcrChars(PROP3)));
         assertFalse(testNode.hasProperty(Text.escapeIllegalJcrChars("jcr:a:b")));
     }
@@ -415,7 +415,6 @@ public class JcrModifiableValueMapTest extends SlingRepositoryTestBase {
         // read properties
         assertEqualsCalendar(calendarValue1, testNode.getProperty(PROP1).getDate());
         assertEqualsCalendar(calendarValue3, testNode.getProperty(PROP3).getDate());
-
     }
 
     /**
@@ -455,15 +454,12 @@ public class JcrModifiableValueMapTest extends SlingRepositoryTestBase {
 
         // from ZonedDateTime
         assertEqualsCalendar(calendar, vm.get(PROP2, Calendar.class)); // to Calendar
-        assertEquals(calendar.getTime(), vm.get(PROP2, Date.class));   // to Date
-        assertEquals(dateAsIso8601, vm.get(PROP2, String.class));      // to String
-
+        assertEquals(calendar.getTime(), vm.get(PROP2, Date.class)); // to Date
+        assertEquals(dateAsIso8601, vm.get(PROP2, String.class)); // to String
 
         // read properties
         assertEqualsCalendar(calendar, testNode.getProperty(PROP1).getDate());
         assertEqualsCalendar(calendar, testNode.getProperty(PROP2).getDate());
         assertEqualsCalendar(calendar, testNode.getProperty(PROP3).getDate());
-
     }
-
 }

--- a/src/test/java/org/apache/sling/jcr/resource/internal/JcrResourceListenerTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/JcrResourceListenerTest.java
@@ -1,27 +1,22 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with this
- * work for additional information regarding copyright ownership. The ASF
- * licenses this file to You under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.sling.jcr.resource.internal;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 import javax.jcr.AccessDeniedException;
 import javax.jcr.Credentials;
@@ -33,6 +28,13 @@ import javax.jcr.Value;
 import javax.jcr.lock.LockException;
 import javax.jcr.nodetype.ConstraintViolationException;
 import javax.jcr.version.VersionException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.apache.jackrabbit.commons.JcrUtils;
 import org.apache.sling.api.resource.observation.ResourceChange;
@@ -90,85 +92,87 @@ public class JcrResourceListenerTest {
         unregisterListener();
         events.clear();
         ObservationReporter observationReporter = getObservationReporter(paths);
-        this.config = new JcrListenerBaseConfig(observationReporter,
-                new SlingRepository() {
+        this.config = new JcrListenerBaseConfig(observationReporter, new SlingRepository() {
 
-                    @Override
-                    public Session login(Credentials credentials, String workspaceName) throws RepositoryException {
-                        return repository.login(credentials, workspaceName);
-                    }
+            @Override
+            public Session login(Credentials credentials, String workspaceName) throws RepositoryException {
+                return repository.login(credentials, workspaceName);
+            }
 
-                    @Override
-                    public Session login(String workspaceName) throws RepositoryException {
-                        return repository.login(workspaceName);
-                    }
+            @Override
+            public Session login(String workspaceName) throws RepositoryException {
+                return repository.login(workspaceName);
+            }
 
-                    @Override
-                    public Session login(Credentials credentials) throws RepositoryException {
-                        return repository.login(credentials);
-                    }
+            @Override
+            public Session login(Credentials credentials) throws RepositoryException {
+                return repository.login(credentials);
+            }
 
-                    @Override
-                    public Session login() throws RepositoryException {
-                        return repository.login();
-                    }
+            @Override
+            public Session login() throws RepositoryException {
+                return repository.login();
+            }
 
-                    @Override
-                    public boolean isStandardDescriptor(String key) {
-                        return repository.isStandardDescriptor(key);
-                    }
+            @Override
+            public boolean isStandardDescriptor(String key) {
+                return repository.isStandardDescriptor(key);
+            }
 
-                    @Override
-                    public boolean isSingleValueDescriptor(String key) {
-                        return repository.isSingleValueDescriptor(key);
-                    }
+            @Override
+            public boolean isSingleValueDescriptor(String key) {
+                return repository.isSingleValueDescriptor(key);
+            }
 
-                    @Override
-                    public Value[] getDescriptorValues(String key) {
-                        return repository.getDescriptorValues(key);
-                    }
+            @Override
+            public Value[] getDescriptorValues(String key) {
+                return repository.getDescriptorValues(key);
+            }
 
-                    @Override
-                    public Value getDescriptorValue(String key) {
-                        return repository.getDescriptorValue(key);
-                    }
+            @Override
+            public Value getDescriptorValue(String key) {
+                return repository.getDescriptorValue(key);
+            }
 
-                    @Override
-                    public String[] getDescriptorKeys() {
-                        return repository.getDescriptorKeys();
-                    }
+            @Override
+            public String[] getDescriptorKeys() {
+                return repository.getDescriptorKeys();
+            }
 
-                    @Override
-                    public String getDescriptor(String key) {
-                        return repository.getDescriptor(key);
-                    }
+            @Override
+            public String getDescriptor(String key) {
+                return repository.getDescriptor(key);
+            }
 
-                    @Override
-                    public Session loginService(String subServiceName, String workspace) throws RepositoryException {
-                        return repository.loginAdministrative(workspace);
-                    }
+            @Override
+            public Session loginService(String subServiceName, String workspace) throws RepositoryException {
+                return repository.loginAdministrative(workspace);
+            }
 
-                    @Override
-                    public Session loginAdministrative(String workspace) throws RepositoryException {
-                        return repository.loginAdministrative(workspace);
-                    }
+            @Override
+            public Session loginAdministrative(String workspace) throws RepositoryException {
+                return repository.loginAdministrative(workspace);
+            }
 
-                    @Override
-                    public String getDefaultWorkspace() {
-                        return repository.getDefaultWorkspace();
-                    }
+            @Override
+            public String getDefaultWorkspace() {
+                return repository.getDefaultWorkspace();
+            }
 
-                    @Override
-                    public Session impersonateFromService(String s, Credentials credentials, String s1) throws LoginException, RepositoryException {
-                        return loginAdministrative(s1).impersonate(credentials);
-                    }
-                });
-        this.listener = new JcrResourceListener(this.config,
-                observationReporter.getObserverConfigurations().get(0));
+            @Override
+            public Session impersonateFromService(String s, Credentials credentials, String s1)
+                    throws LoginException, RepositoryException {
+                return loginAdministrative(s1).impersonate(credentials);
+            }
+        });
+        this.listener = new JcrResourceListener(
+                this.config, observationReporter.getObserverConfigurations().get(0));
     }
 
     @After
-    public void tearDown() throws AccessDeniedException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public void tearDown()
+            throws AccessDeniedException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         unregisterListener();
         if (adminSession.itemExists("/apps")) {
             adminSession.removeItem("/apps");
@@ -237,9 +241,11 @@ public class JcrResourceListenerTest {
         adminSession.save();
         Thread.sleep(3500);
 
-        assertTrue("Events must contain \"added\" for path \"" + movedPath + "\"",
+        assertTrue(
+                "Events must contain \"added\" for path \"" + movedPath + "\"",
                 events.stream().anyMatch(e -> e.getPath().equals(movedPath) && e.getType() == ChangeType.ADDED));
-        assertTrue("Events must contain \"removed\" for path \"" + createdPath + "\"",
+        assertTrue(
+                "Events must contain \"removed\" for path \"" + createdPath + "\"",
                 events.stream().anyMatch(e -> e.getPath().equals(createdPath) && e.getType() == ChangeType.REMOVED));
     }
 
@@ -255,9 +261,11 @@ public class JcrResourceListenerTest {
 
         // 1 added + 1 removed event for roots
         assertEquals("Events must only contain 2 events but has " + events.toString(), 2, events.size());
-        assertTrue("Events must contain \"added\" for path \"/apps2\"",
+        assertTrue(
+                "Events must contain \"added\" for path \"/apps2\"",
                 events.stream().anyMatch(e -> e.getPath().equals("/apps2") && e.getType() == ChangeType.ADDED));
-        assertTrue("Events must contain \"removed\" for path \"/apps\"",
+        assertTrue(
+                "Events must contain \"removed\" for path \"/apps\"",
                 events.stream().anyMatch(e -> e.getPath().equals("/apps") && e.getType() == ChangeType.REMOVED));
     }
 
@@ -269,9 +277,12 @@ public class JcrResourceListenerTest {
         adminSession.save();
         Thread.sleep(3500);
         String expectedAddedPath = "/apps/test" + createdPath;
-        assertTrue("Events must contain \"added\" for path \"" + expectedAddedPath + "\"",
-                events.stream().anyMatch(e -> e.getPath().equals(expectedAddedPath) && e.getType() == ChangeType.ADDED));
-        assertFalse("Events must not contain any \"removed\" events",
+        assertTrue(
+                "Events must contain \"added\" for path \"" + expectedAddedPath + "\"",
+                events.stream()
+                        .anyMatch(e -> e.getPath().equals(expectedAddedPath) && e.getType() == ChangeType.ADDED));
+        assertFalse(
+                "Events must not contain any \"removed\" events",
                 events.stream().anyMatch(e -> e.getType() == ChangeType.REMOVED));
     }
 
@@ -286,7 +297,8 @@ public class JcrResourceListenerTest {
         String expectedPath = "/apps";
         // 1 removed events for the moved root only
         assertEquals("Events must only contain 1 events but has " + events.toString(), 1, events.size());
-        assertTrue("Events must contain \"removed\" for path \"" + expectedPath + "\"",
+        assertTrue(
+                "Events must contain \"removed\" for path \"" + expectedPath + "\"",
                 events.stream().anyMatch(e -> e.getPath().equals(expectedPath) && e.getType() == ChangeType.REMOVED));
     }
 
@@ -300,7 +312,8 @@ public class JcrResourceListenerTest {
 
         // only an added event for the root is received
         assertEquals("Events must only contain 1 event but has " + events.toString(), 1, events.size());
-        assertTrue("Events must contain \"added\" for root path \"/apps/test\"",
+        assertTrue(
+                "Events must contain \"added\" for root path \"/apps/test\"",
                 events.stream().anyMatch(e -> e.getPath().equals("/apps/test") && e.getType() == ChangeType.ADDED));
     }
 
@@ -316,8 +329,11 @@ public class JcrResourceListenerTest {
 
         // 2 removed events for the whole subgraph below the observed path is received
         assertEquals("Events must only contain 2 events but has " + events.toString(), 2, events.size());
-        assertTrue("Events must contain \"added\" for root path \"/apps/test\"",
-                events.stream().anyMatch(e -> e.getPath().equals("/apps/test" + createdPath) && e.getType() == ChangeType.REMOVED));
+        assertTrue(
+                "Events must contain \"added\" for root path \"/apps/test\"",
+                events.stream()
+                        .anyMatch(e ->
+                                e.getPath().equals("/apps/test" + createdPath) && e.getType() == ChangeType.REMOVED));
     }
 
     @Test
@@ -394,7 +410,7 @@ public class JcrResourceListenerTest {
 
         try (final JcrResourceListener l = new JcrResourceListener(this.config, observerConfig)) {
             final String rootName = "test_" + System.currentTimeMillis();
-            for (final String path : new String[]{"/libs", "/", "/apps", "/content"}) {
+            for (final String path : new String[] {"/libs", "/", "/apps", "/content"}) {
                 final Node parent;
                 if (!session.nodeExists(path)) {
                     parent = createNode(session, path);
@@ -481,9 +497,11 @@ public class JcrResourceListenerTest {
     private class SimpleObservationReporter implements ObservationReporter {
 
         private final String[] paths;
+
         public SimpleObservationReporter(String... paths) {
             this.paths = paths;
         }
+
         @Override
         public void reportChanges(Iterable<ResourceChange> changes, boolean distribute) {
             for (ResourceChange c : changes) {
@@ -529,9 +547,9 @@ public class JcrResourceListenerTest {
         }
 
         @Override
-        public void reportChanges(@NotNull ObserverConfiguration config, @NotNull Iterable<ResourceChange> changes, boolean distribute) {
+        public void reportChanges(
+                @NotNull ObserverConfiguration config, @NotNull Iterable<ResourceChange> changes, boolean distribute) {
             this.reportChanges(changes, distribute);
         }
     }
-
 }

--- a/src/test/java/org/apache/sling/jcr/resource/internal/JcrSystemUserValidatorTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/JcrSystemUserValidatorTest.java
@@ -1,31 +1,29 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.sling.jcr.resource.internal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.Collections;
-
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 
 import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.user.Group;
@@ -38,6 +36,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class JcrSystemUserValidatorTest {
 
@@ -53,8 +55,9 @@ public class JcrSystemUserValidatorTest {
     public final SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
 
     @Before
-    public void setUp() throws IllegalArgumentException, IllegalAccessException, RepositoryException,
-            NoSuchFieldException, SecurityException {
+    public void setUp()
+            throws IllegalArgumentException, IllegalAccessException, RepositoryException, NoSuchFieldException,
+                    SecurityException {
         jcrSystemUserValidator = new JcrSystemUserValidator();
         final Field repositoryField = jcrSystemUserValidator.getClass().getDeclaredField("repository");
         repositoryField.setAccessible(true);
@@ -90,7 +93,6 @@ public class JcrSystemUserValidatorTest {
             public boolean allow_only_system_user() {
                 return allowOnlySystemUsers;
             }
-
         };
         jcrSystemUserValidator.activate(config);
     }
@@ -99,11 +101,11 @@ public class JcrSystemUserValidatorTest {
     public void testIsValidWithEnforcementOfSystemUsersEnabled() throws Exception {
         setAllowOnlySystemUsers(true);
 
-        //testing null user
+        // testing null user
         assertFalse(jcrSystemUserValidator.isValid((String) null, null, null));
-        //testing not existing user     
+        // testing not existing user
         assertFalse(jcrSystemUserValidator.isValid("notExisting", null, null));
-        //administrators group is not a valid user  (also not a system user)
+        // administrators group is not a valid user  (also not a system user)
         assertFalse(jcrSystemUserValidator.isValid(group.getID(), null, null));
         // systemUser is valid
         assertTrue(jcrSystemUserValidator.isValid(systemUser.getID(), null, null));
@@ -113,23 +115,25 @@ public class JcrSystemUserValidatorTest {
     public void testIsValidPrincipalNamesWithEnforcementOfSystemUsersEnabled() throws Exception {
         setAllowOnlySystemUsers(true);
 
-        //testing null principal names
+        // testing null principal names
         assertFalse(jcrSystemUserValidator.isValid((Iterable<String>) null, null, null));
-        //testing not existing user
+        // testing not existing user
         assertFalse(jcrSystemUserValidator.isValid(Collections.singleton("notExisting"), null, null));
-        //administrators group is not a valid user  (also not a system user)
-        assertFalse(jcrSystemUserValidator.isValid(Collections.singleton(group.getPrincipal().getName()), null, null));
+        // administrators group is not a valid user  (also not a system user)
+        assertFalse(jcrSystemUserValidator.isValid(
+                Collections.singleton(group.getPrincipal().getName()), null, null));
         // systemUser is valid
-        assertTrue(jcrSystemUserValidator.isValid(Collections.singleton(systemUser.getPrincipal().getName()), null, null));
+        assertTrue(jcrSystemUserValidator.isValid(
+                Collections.singleton(systemUser.getPrincipal().getName()), null, null));
     }
 
     @Test
     public void testIsValidWithEnforcementOfSystemUsersDisabled() throws Exception {
         setAllowOnlySystemUsers(false);
 
-        //testing null user
+        // testing null user
         assertFalse(jcrSystemUserValidator.isValid((String) null, null, null));
-        //testing not existing user (is considered valid here)
+        // testing not existing user (is considered valid here)
         assertTrue(jcrSystemUserValidator.isValid("notExisting", null, null));
         // administrators group is not a user at all (but considered valid)
         assertTrue(jcrSystemUserValidator.isValid(group.getID(), null, null));
@@ -141,14 +145,16 @@ public class JcrSystemUserValidatorTest {
     public void testIsValidPrincipalNamesWithEnforcementOfSystemUsersDisabled() throws Exception {
         setAllowOnlySystemUsers(false);
 
-        //testing null principal names
+        // testing null principal names
         assertFalse(jcrSystemUserValidator.isValid((Iterable<String>) null, null, null));
-        //testing not existing user (is considered valid here)
+        // testing not existing user (is considered valid here)
         assertTrue(jcrSystemUserValidator.isValid(Collections.singleton("notExisting"), null, null));
         // administrators group is not a user at all (but considered valid)
-        assertTrue(jcrSystemUserValidator.isValid(Collections.singleton(group.getPrincipal().getName()), null, null));
+        assertTrue(jcrSystemUserValidator.isValid(
+                Collections.singleton(group.getPrincipal().getName()), null, null));
         // systemUser is valid
-        assertTrue(jcrSystemUserValidator.isValid(Collections.singleton(systemUser.getPrincipal().getName()), null, null));
+        assertTrue(jcrSystemUserValidator.isValid(
+                Collections.singleton(systemUser.getPrincipal().getName()), null, null));
     }
 
     @Test
@@ -167,7 +173,9 @@ public class JcrSystemUserValidatorTest {
 
         // Validation information is cached internally - need to test twice
         // to activate all code paths
-        assertTrue(jcrSystemUserValidator.isValid(Collections.singleton(systemUser.getPrincipal().getName()), null, null));
-        assertTrue(jcrSystemUserValidator.isValid(Collections.singleton(systemUser.getPrincipal().getName()), null, null));
+        assertTrue(jcrSystemUserValidator.isValid(
+                Collections.singleton(systemUser.getPrincipal().getName()), null, null));
+        assertTrue(jcrSystemUserValidator.isValid(
+                Collections.singleton(systemUser.getPrincipal().getName()), null, null));
     }
 }

--- a/src/test/java/org/apache/sling/jcr/resource/internal/JcrValueMapTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/JcrValueMapTest.java
@@ -25,39 +25,34 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 public class JcrValueMapTest extends SlingRepositoryTestBase {
-    
+
     private Node rootNode;
     HelperData helperData;
-    
+
     @Override
     protected void setUp() throws Exception {
         super.setUp();
         String rootPath = "/test_" + System.currentTimeMillis();
-        rootNode = getSession().getRootNode().addNode(rootPath.substring(1),
-                "nt:unstructured");
+        rootNode = getSession().getRootNode().addNode(rootPath.substring(1), "nt:unstructured");
         rootNode.setProperty("string", "test");
         getSession().save();
         helperData = Mockito.mock(HelperData.class);
     }
-    
-    
+
     //  Tests with null as default value and class must pass, see https://issues.apache.org/jira/browse/SLING-11567
-    
+
     @Test
     public void testGetWithDefaultValue() {
-       JcrValueMap vm = new JcrValueMap(rootNode, helperData);
-       assertEquals("test", vm.get("string","default"));
-       assertEquals("default", vm.get("nonexistent","default"));
-       assertNull(vm.get("nonexistent",null));
+        JcrValueMap vm = new JcrValueMap(rootNode, helperData);
+        assertEquals("test", vm.get("string", "default"));
+        assertEquals("default", vm.get("nonexistent", "default"));
+        assertNull(vm.get("nonexistent", null));
     }
-    
+
     @Test
     public void testGetWithClass() {
         JcrValueMap vm = new JcrValueMap(rootNode, helperData);
-        assertEquals("test", vm.get("string",String.class));
-        assertEquals("test", vm.get("string",null)); 
+        assertEquals("test", vm.get("string", String.class));
+        assertEquals("test", vm.get("string", null));
     }
-    
-   
-
 }

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/JcrNodeResourceIteratorTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/JcrNodeResourceIteratorTest.java
@@ -18,24 +18,23 @@
  */
 package org.apache.sling.jcr.resource.internal.helper;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.NoSuchElementException;
-import java.util.concurrent.atomic.AtomicReference;
-
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import junit.framework.TestCase;
 import org.apache.jackrabbit.commons.JcrUtils;
 import org.apache.jackrabbit.commons.iterator.NodeIteratorAdapter;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.jcr.resource.internal.HelperData;
 import org.apache.sling.jcr.resource.internal.helper.jcr.JcrNodeResourceIterator;
 import org.apache.sling.testing.mock.jcr.MockJcr;
-
-import junit.framework.TestCase;
 
 public class JcrNodeResourceIteratorTest extends TestCase {
 

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/JcrPropertyMapCacheEntryTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/JcrPropertyMapCacheEntryTest.java
@@ -18,17 +18,14 @@
  */
 package org.apache.sling.jcr.resource.internal.helper;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.PropertyType;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Value;
+import javax.jcr.ValueFactory;
+import javax.jcr.ValueFormatException;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -43,21 +40,23 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.jcr.Node;
-import javax.jcr.Property;
-import javax.jcr.PropertyType;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import javax.jcr.Value;
-import javax.jcr.ValueFactory;
-import javax.jcr.ValueFormatException;
-
+import com.google.common.collect.Maps;
 import org.apache.jackrabbit.value.BooleanValue;
 import org.apache.jackrabbit.value.ValueFactoryImpl;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.collect.Maps;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 /**
  * Testcase for {@link JcrPropertyMapCacheEntry}
@@ -237,7 +236,8 @@ public class JcrPropertyMapCacheEntryTest {
         when(prop.getType()).thenReturn(PropertyType.BINARY);
         when(prop.isMultiple()).thenReturn(true);
         when(prop.getValue()).thenThrow(new ValueFormatException("multi-valued"));
-        Value[] vs = new Value[] {vf.createValue("10.7", PropertyType.BINARY), vf.createValue("10.7", PropertyType.BINARY)};
+        Value[] vs =
+                new Value[] {vf.createValue("10.7", PropertyType.BINARY), vf.createValue("10.7", PropertyType.BINARY)};
         when(prop.getValues()).thenReturn(vs);
         when(prop.getLength()).thenThrow(new ValueFormatException("multi-valued"));
         when(prop.getLengths()).thenReturn(new long[] {4L, 4L});
@@ -273,9 +273,10 @@ public class JcrPropertyMapCacheEntryTest {
             oos.writeObject(Maps.newHashMap());
         }
 
-        JcrPropertyMapCacheEntry entry = new JcrPropertyMapCacheEntry(new ByteArrayInputStream(out.toByteArray()), node);
+        JcrPropertyMapCacheEntry entry =
+                new JcrPropertyMapCacheEntry(new ByteArrayInputStream(out.toByteArray()), node);
         // same type
-        Map<?,?> result = entry.convertToType(HashMap.class, node, null);
+        Map<?, ?> result = entry.convertToType(HashMap.class, node, null);
         assertNotNull(result);
         verifyNoMoreInteractions(node);
     }
@@ -287,7 +288,8 @@ public class JcrPropertyMapCacheEntryTest {
             oos.writeObject(new LinkedHashMap<>());
         }
 
-        JcrPropertyMapCacheEntry entry = new JcrPropertyMapCacheEntry(new ByteArrayInputStream(out.toByteArray()), node);
+        JcrPropertyMapCacheEntry entry =
+                new JcrPropertyMapCacheEntry(new ByteArrayInputStream(out.toByteArray()), node);
         // different type that cannot be converted
         Calendar result = entry.convertToType(Calendar.class, node, LinkedHashMap.class.getClassLoader());
         assertNull(result);

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/BinaryDownloadUriProviderTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/BinaryDownloadUriProviderTest.java
@@ -18,20 +18,16 @@
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
-
-import javax.jcr.Node;
-import javax.jcr.Property;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 
 import org.apache.jackrabbit.api.binary.BinaryDownload;
 import org.apache.jackrabbit.api.binary.BinaryDownloadOptions;
@@ -51,6 +47,10 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BinaryDownloadUriProviderTest {
@@ -87,7 +87,8 @@ public class BinaryDownloadUriProviderTest {
         };
         Mockito.when(property.getBinary()).thenReturn(binaryDownload);
         URI myUri = new URI("https://example.com/mybinary");
-        Mockito.when(binaryDownload.getURI(ArgumentMatchers.any(BinaryDownloadOptions.class))).thenReturn(myUri);
+        Mockito.when(binaryDownload.getURI(ArgumentMatchers.any(BinaryDownloadOptions.class)))
+                .thenReturn(myUri);
 
         assertEquals(myUri, uriProvider.toURI(fileResource, Scope.EXTERNAL, Operation.READ));
         ArgumentCaptor<BinaryDownloadOptions> argumentCaptor = ArgumentCaptor.forClass(BinaryDownloadOptions.class);
@@ -99,26 +100,38 @@ public class BinaryDownloadUriProviderTest {
 
     @Test
     public void testPropertyWithoutExternallyAccessibleBlobStore() {
-        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> uriProvider.toURI(fileResource, Scope.EXTERNAL, Operation.READ));
-        assertEquals("Cannot provide url for downloading the binary property at '/test/jcr:content/jcr:data'", e.getMessage());
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class, () -> uriProvider.toURI(fileResource, Scope.EXTERNAL, Operation.READ));
+        assertEquals(
+                "Cannot provide url for downloading the binary property at '/test/jcr:content/jcr:data'",
+                e.getMessage());
     }
 
     @Test
     public void testNoPrimaryPropertyUri() {
-        Resource resource = context.create().resource("/content/test1", Collections.singletonMap("jcr:primaryProperty", "nt:folder"));
-        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> uriProvider.toURI(resource, Scope.PUBLIC, Operation.READ));
+        Resource resource = context.create()
+                .resource("/content/test1", Collections.singletonMap("jcr:primaryProperty", "nt:folder"));
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class, () -> uriProvider.toURI(resource, Scope.PUBLIC, Operation.READ));
         assertEquals("Node does not have a primary property", e.getMessage());
     }
 
     @Test
     public void testUnsupportedScope() {
-        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> uriProvider.toURI(fileResource, Scope.INTERNAL, Operation.READ));
-        assertEquals("This provider only provides URIs for 'READ' operations in scope 'PUBLIC' or 'EXTERNAL', but not for scope 'INTERNAL' and operation 'READ'", e.getMessage());
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class, () -> uriProvider.toURI(fileResource, Scope.INTERNAL, Operation.READ));
+        assertEquals(
+                "This provider only provides URIs for 'READ' operations in scope 'PUBLIC' or 'EXTERNAL', but not for scope 'INTERNAL' and operation 'READ'",
+                e.getMessage());
     }
 
     @Test
     public void testUnsupportedOperation() {
-        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> uriProvider.toURI(fileResource, Scope.EXTERNAL, Operation.UPDATE));
-        assertEquals("This provider only provides URIs for 'READ' operations in scope 'PUBLIC' or 'EXTERNAL', but not for scope 'EXTERNAL' and operation 'UPDATE'", e.getMessage());
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class,
+                () -> uriProvider.toURI(fileResource, Scope.EXTERNAL, Operation.UPDATE));
+        assertEquals(
+                "This provider only provides URIs for 'READ' operations in scope 'PUBLIC' or 'EXTERNAL', but not for scope 'EXTERNAL' and operation 'UPDATE'",
+                e.getMessage());
     }
 }

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/ContextUtilTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/ContextUtilTest.java
@@ -1,29 +1,32 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
+
+import javax.jcr.Session;
+
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.sling.jcr.resource.internal.HelperData;
 import org.apache.sling.spi.resource.provider.ResolveContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import javax.jcr.Session;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
@@ -35,21 +38,23 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class ContextUtilTest {
-    
+
     private JcrProviderState state;
     private ResolveContext<JcrProviderState> ctx;
-    
+
     @Before
     public void before() {
         state = mock(JcrProviderState.class);
-        ctx = when(mock(ResolveContext.class).getProviderState()).thenReturn(state).getMock();
+        ctx = when(mock(ResolveContext.class).getProviderState())
+                .thenReturn(state)
+                .getMock();
     }
-    
+
     @After
     public void after() {
         reset(state, ctx);
     }
-    
+
     @Test
     public void testGetHelperData() {
         HelperData hd = new HelperData(new AtomicReference<>(), new AtomicReference<>());
@@ -80,7 +85,7 @@ public class ContextUtilTest {
         when(state.getSession()).thenReturn(session);
 
         assertSame(session, ContextUtil.getSession(ctx));
-        
+
         verify(state).getSession();
         verify(ctx).getProviderState();
         verifyNoMoreInteractions(ctx, state);
@@ -89,7 +94,7 @@ public class ContextUtilTest {
     @Test
     public void testNullProviderState() {
         when(ctx.getProviderState()).thenReturn(null);
-        
+
         try {
             ContextUtil.getHelperData(ctx);
             fail("IllegalStateException expected");
@@ -110,10 +115,9 @@ public class ContextUtilTest {
         } catch (IllegalStateException e) {
             // success
         }
-        
+
         verify(ctx, times(3)).getProviderState();
         verifyNoMoreInteractions(ctx);
         verifyNoMoreInteractions(state);
     }
-
 }

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrItemResourceFactoryTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrItemResourceFactoryTest.java
@@ -18,15 +18,15 @@
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
-import java.lang.reflect.Proxy;
-import java.util.concurrent.atomic.AtomicReference;
-
 import javax.jcr.GuestCredentials;
 import javax.jcr.Item;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.security.Privilege;
+
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.commons.JcrUtils;
@@ -63,7 +63,7 @@ public class JcrItemResourceFactoryTest extends SlingRepositoryTestBase {
 
         nonJackrabbitSession = (Session) Proxy.newProxyInstance(
                 getClass().getClassLoader(),
-                new Class<?>[]{Session.class},
+                new Class<?>[] {Session.class},
                 (proxy, method, args) -> method.invoke(session, args));
 
         AccessControlUtils.allow(node, EveryonePrincipal.NAME, Privilege.JCR_READ);
@@ -149,7 +149,8 @@ public class JcrItemResourceFactoryTest extends SlingRepositoryTestBase {
 
     public void testGetNodeByIdentifierConfigEnabled() throws Exception {
         ComponentContext ctx = mock(ComponentContext.class);
-        when(ctx.locateService(ArgumentMatchers.anyString(), Mockito.any())).thenReturn(SlingRepositoryProvider.getRepository());
+        when(ctx.locateService(ArgumentMatchers.anyString(), Mockito.any()))
+                .thenReturn(SlingRepositoryProvider.getRepository());
 
         JcrResourceProvider.Configuration configuration = mock(JcrResourceProvider.Configuration.class);
         when(configuration.resource_addressingById()).thenReturn(true);
@@ -160,14 +161,15 @@ public class JcrItemResourceFactoryTest extends SlingRepositoryTestBase {
         String identifier = referenceableNode.getIdentifier();
         String uuid = referenceableNode.getProperty(JcrConstants.JCR_UUID).getString();
         assertEquals(identifier, uuid);
-        Item referenceableItem =
-                new JcrItemResourceFactory(session, helper).getItemOrNull(JcrItemResourceFactory.SEARCH_BY_ID_PREFIX + referenceableNode.getIdentifier());
+        Item referenceableItem = new JcrItemResourceFactory(session, helper)
+                .getItemOrNull(JcrItemResourceFactory.SEARCH_BY_ID_PREFIX + referenceableNode.getIdentifier());
         assertNotNull(referenceableItem);
         assertTrue(referenceableItem.isNode());
         assertEquals(REFERENCEABLE_NODE_PATH, referenceableItem.getPath());
 
         // the node identifier in this case is the path
-        Item nodeItem = new JcrItemResourceFactory(session, helper).getItemOrNull(JcrItemResourceFactory.SEARCH_BY_ID_PREFIX + node.getIdentifier());
+        Item nodeItem = new JcrItemResourceFactory(session, helper)
+                .getItemOrNull(JcrItemResourceFactory.SEARCH_BY_ID_PREFIX + node.getIdentifier());
         assertNotNull(nodeItem);
         assertTrue(nodeItem.isNode());
         assertEquals(EXISTING_NODE_PATH, nodeItem.getPath());
@@ -178,8 +180,8 @@ public class JcrItemResourceFactoryTest extends SlingRepositoryTestBase {
         String identifier = referenceableNode.getIdentifier();
         String uuid = referenceableNode.getProperty(JcrConstants.JCR_UUID).getString();
         assertEquals(identifier, uuid);
-        Item referenceableItem =
-                new JcrItemResourceFactory(session, helper).getItemOrNull(JcrItemResourceFactory.SEARCH_BY_ID_PREFIX + referenceableNode.getIdentifier());
+        Item referenceableItem = new JcrItemResourceFactory(session, helper)
+                .getItemOrNull(JcrItemResourceFactory.SEARCH_BY_ID_PREFIX + referenceableNode.getIdentifier());
         assertNull(referenceableItem);
     }
 

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrItemResourceTestBase.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrItemResourceTestBase.java
@@ -18,11 +18,11 @@
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
-import java.io.IOException;
-import java.io.InputStream;
-
 import javax.jcr.NamespaceRegistry;
 import javax.jcr.Node;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 import org.apache.sling.api.SlingConstants;
 import org.apache.sling.jcr.resource.api.JcrResourceConstants;
@@ -35,8 +35,7 @@ public abstract class JcrItemResourceTestBase extends SlingRepositoryTestBase {
 
     protected static final String TEST_ENCODING = "ISO-8859-1";
 
-    protected static final byte[] TEST_DATA = {'S', 'o', 'm', 'e', ' ', 'T',
-            'e', 's', 't'};
+    protected static final byte[] TEST_DATA = {'S', 'o', 'm', 'e', ' ', 'T', 'e', 's', 't'};
 
     protected String rootPath;
 
@@ -51,15 +50,13 @@ public abstract class JcrItemResourceTestBase extends SlingRepositoryTestBase {
 
         try {
             NamespaceRegistry nsr = session.getWorkspace().getNamespaceRegistry();
-            nsr.registerNamespace(SlingConstants.NAMESPACE_PREFIX,
-                    JcrResourceConstants.SLING_NAMESPACE_URI);
+            nsr.registerNamespace(SlingConstants.NAMESPACE_PREFIX, JcrResourceConstants.SLING_NAMESPACE_URI);
         } catch (Exception e) {
             // don't care for now
         }
 
         rootPath = "/test" + System.currentTimeMillis();
-        rootNode = getSession().getRootNode().addNode(rootPath.substring(1),
-                "nt:unstructured");
+        rootNode = getSession().getRootNode().addNode(rootPath.substring(1), "nt:unstructured");
         getSession().save();
     }
 
@@ -73,8 +70,7 @@ public abstract class JcrItemResourceTestBase extends SlingRepositoryTestBase {
         super.tearDown();
     }
 
-    protected void assertEquals(byte[] expected, InputStream actual)
-            throws IOException {
+    protected void assertEquals(byte[] expected, InputStream actual) throws IOException {
         if (actual == null) {
             fail("Resource stream is null");
         } else {

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrNodeResourceTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrNodeResourceTest.java
@@ -18,6 +18,10 @@
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -26,10 +30,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-
-import javax.jcr.Node;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.resource.ModifiableValueMap;
@@ -60,17 +60,16 @@ public class JcrNodeResourceTest extends JcrItemResourceTestBase {
         linkedFile.setProperty(JcrConstants.JCR_CONTENT, file);
         session.save();
 
-        JcrNodeResource linkedFileResource = new JcrNodeResource(null, linkedFile.getPath(), null, linkedFile, getHelperData());
+        JcrNodeResource linkedFileResource =
+                new JcrNodeResource(null, linkedFile.getPath(), null, linkedFile, getHelperData());
         assertEquals(TEST_DATA, linkedFileResource.adaptTo(InputStream.class));
-
     }
 
     public void testNtFileNtResource() throws Exception {
 
         String name = "file";
         Node file = rootNode.addNode(name, JcrConstants.NT_FILE);
-        Node res = file.addNode(JcrConstants.JCR_CONTENT,
-                JcrConstants.NT_RESOURCE);
+        Node res = file.addNode(JcrConstants.JCR_CONTENT, JcrConstants.NT_RESOURCE);
         setupResource(res);
         getSession().save();
 
@@ -87,8 +86,7 @@ public class JcrNodeResourceTest extends JcrItemResourceTestBase {
 
         String name = "fileunstructured";
         Node file = rootNode.addNode(name, JcrConstants.NT_FILE);
-        Node res = file.addNode(JcrConstants.JCR_CONTENT,
-                JcrConstants.NT_UNSTRUCTURED);
+        Node res = file.addNode(JcrConstants.JCR_CONTENT, JcrConstants.NT_UNSTRUCTURED);
         setupResource(res);
         getSession().save();
 
@@ -182,7 +180,8 @@ public class JcrNodeResourceTest extends JcrItemResourceTestBase {
         assertEquals(otherSuperTypeName, jnr.getResourceSuperType());
 
         // remove direct property to get supertype again
-        node.getProperty(JcrResourceConstants.SLING_RESOURCE_SUPER_TYPE_PROPERTY).remove();
+        node.getProperty(JcrResourceConstants.SLING_RESOURCE_SUPER_TYPE_PROPERTY)
+                .remove();
         getSession().save();
 
         jnr = new JcrNodeResource(null, node.getPath(), null, node, getHelperData());
@@ -254,8 +253,7 @@ public class JcrNodeResourceTest extends JcrItemResourceTestBase {
         byte[] utf8bytes = "Übersättigung".getBytes(StandardCharsets.UTF_8);
         String name = "utf8file";
         Node file = rootNode.addNode(name, JcrConstants.NT_FILE);
-        Node res = file.addNode(JcrConstants.JCR_CONTENT,
-                JcrConstants.NT_RESOURCE);
+        Node res = file.addNode(JcrConstants.JCR_CONTENT, JcrConstants.NT_RESOURCE);
 
         res.setProperty(JcrConstants.JCR_LASTMODIFIED, TEST_MODIFIED);
         res.setProperty(JcrConstants.JCR_MIMETYPE, TEST_TYPE);
@@ -271,13 +269,11 @@ public class JcrNodeResourceTest extends JcrItemResourceTestBase {
         assertEquals(utf8bytes.length, jnr.getResourceMetadata().getContentLength());
     }
 
-
     private void setupResource(Node res) throws RepositoryException {
         res.setProperty(JcrConstants.JCR_LASTMODIFIED, TEST_MODIFIED);
         res.setProperty(JcrConstants.JCR_MIMETYPE, TEST_TYPE);
         res.setProperty(JcrConstants.JCR_ENCODING, TEST_ENCODING);
-        res.setProperty(JcrConstants.JCR_DATA, new ByteArrayInputStream(
-                TEST_DATA));
+        res.setProperty(JcrConstants.JCR_DATA, new ByteArrayInputStream(TEST_DATA));
     }
 
     private void assertResourceMetaData(ResourceMetadata rm) {

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrPropertyResourceTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrPropertyResourceTest.java
@@ -18,17 +18,15 @@
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
-import static org.junit.Assert.assertEquals;
+import javax.jcr.Property;
+import javax.jcr.PropertyType;
+import javax.jcr.RepositoryException;
 
 import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map.Entry;
-
-import javax.jcr.Property;
-import javax.jcr.PropertyType;
-import javax.jcr.RepositoryException;
 
 import org.apache.sling.api.resource.ResourceResolver;
 import org.jmock.Expectations;
@@ -37,6 +35,8 @@ import org.jmock.integration.junit4.JMock;
 import org.jmock.integration.junit4.JUnit4Mockery;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * JcrPropertyResourceTest ...
@@ -48,37 +48,45 @@ public class JcrPropertyResourceTest {
 
     @Test
     public void testCorrectUTF8ByteLength() throws RepositoryException, UnsupportedEncodingException {
-        final HashMap<Object, Integer> testData = new HashMap<Object, Integer>() {{
-            put("some random ascii string", PropertyType.STRING);
-            put("русский язык", PropertyType.STRING);
-            put("贛語", PropertyType.STRING);
-            put("string with ümlaut", PropertyType.STRING);
-            put(true, PropertyType.BOOLEAN);
-            put(1000L, PropertyType.LONG);
-            put(BigDecimal.TEN, PropertyType.DECIMAL);
-        }};
+        final HashMap<Object, Integer> testData = new HashMap<Object, Integer>() {
+            {
+                put("some random ascii string", PropertyType.STRING);
+                put("русский язык", PropertyType.STRING);
+                put("贛語", PropertyType.STRING);
+                put("string with ümlaut", PropertyType.STRING);
+                put(true, PropertyType.BOOLEAN);
+                put(1000L, PropertyType.LONG);
+                put(BigDecimal.TEN, PropertyType.DECIMAL);
+            }
+        };
 
         final ResourceResolver resolver = this.context.mock(ResourceResolver.class);
         for (final Entry<Object, Integer> data : testData.entrySet()) {
             final String stringValue = data.getKey().toString();
             final long stringByteLength = stringValue.getBytes(StandardCharsets.UTF_8).length;
             final Property property = this.context.mock(Property.class, stringValue);
-            this.context.checking(new Expectations() {{
-                ignoring(resolver);
-                allowing(property).getParent();
-                allowing(property).getName();
-                allowing(property).isMultiple();
-                will(returnValue(false));
-                allowing(property).getLength();
-                will(returnValue((long) stringValue.length()));
+            this.context.checking(new Expectations() {
+                {
+                    ignoring(resolver);
+                    allowing(property).getParent();
+                    allowing(property).getName();
+                    allowing(property).isMultiple();
+                    will(returnValue(false));
+                    allowing(property).getLength();
+                    will(returnValue((long) stringValue.length()));
 
-                allowing(property).getType();
-                will(returnValue(data.getValue()));
-                allowing(property).getString();
-                will(returnValue(stringValue));
-            }});
-            final JcrPropertyResource propResource = new JcrPropertyResource(resolver, "/path/to/string-property", null, property);
-            assertEquals("Byte length of " + stringValue, stringByteLength, propResource.getResourceMetadata().getContentLength());
+                    allowing(property).getType();
+                    will(returnValue(data.getValue()));
+                    allowing(property).getString();
+                    will(returnValue(stringValue));
+                }
+            });
+            final JcrPropertyResource propResource =
+                    new JcrPropertyResource(resolver, "/path/to/string-property", null, property);
+            assertEquals(
+                    "Byte length of " + stringValue,
+                    stringByteLength,
+                    propResource.getResourceMetadata().getContentLength());
         }
     }
 }

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProviderSessionHandlingTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProviderSessionHandlingTest.java
@@ -18,16 +18,16 @@
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import javax.jcr.Credentials;
 import javax.jcr.LoginException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.Value;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
@@ -63,7 +63,11 @@ import static org.mockito.Mockito.when;
 @RunWith(Parameterized.class)
 public class JcrResourceProviderSessionHandlingTest {
 
-    private enum LoginStyle {USER, SESSION, SERVICE}
+    private enum LoginStyle {
+        USER,
+        SESSION,
+        SERVICE
+    }
 
     private static final String AUTH_USER = "admin";
     private static final char[] AUTH_PASSWORD = "admin".toCharArray();
@@ -73,8 +77,8 @@ public class JcrResourceProviderSessionHandlingTest {
     public static List<Object[]> data() {
 
         LoginStyle[] loginStyles = LoginStyle.values();
-        boolean[] sudoOptions = new boolean[]{false, true};
-        boolean[] cloneOptions = new boolean[]{false, true};
+        boolean[] sudoOptions = new boolean[] {false, true};
+        boolean[] cloneOptions = new boolean[] {false, true};
 
         // Generate all possible combinations into data.
         List<Object[]> data = new ArrayList<>();
@@ -190,7 +194,8 @@ public class JcrResourceProviderSessionHandlingTest {
         }
 
         @Override
-        public Session impersonateFromService(String s, Credentials credentials, String s1) throws LoginException, RepositoryException {
+        public Session impersonateFromService(String s, Credentials credentials, String s1)
+                throws LoginException, RepositoryException {
             return loginAdministrative(s1).impersonate(credentials);
         }
     }
@@ -310,5 +315,4 @@ public class JcrResourceProviderSessionHandlingTest {
 
         assertNotSame(explicitSession, jcrProviderState.getSession());
     }
-
 }

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProviderTest.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrResourceProviderTest.java
@@ -18,14 +18,14 @@
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
 import java.security.Principal;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
-
-import javax.jcr.Node;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.commons.JcrUtils;
@@ -66,7 +66,8 @@ public class JcrResourceProviderTest extends SlingRepositoryTestBase {
         // create the session
         session = getSession();
         ctx = mock(ComponentContext.class);
-        when(ctx.locateService(ArgumentMatchers.anyString(), Mockito.any())).thenReturn(SlingRepositoryProvider.getRepository());
+        when(ctx.locateService(ArgumentMatchers.anyString(), Mockito.any()))
+                .thenReturn(SlingRepositoryProvider.getRepository());
         JcrResourceProvider.Configuration configuration = mock(JcrResourceProvider.Configuration.class);
         jcrResourceProvider = new JcrResourceProvider();
         jcrResourceProvider.activate(ctx, configuration);
@@ -146,10 +147,14 @@ public class JcrResourceProviderTest extends SlingRepositoryTestBase {
         session.save();
 
         ResolveContext ctx = mockResolveContext();
-        Resource rootResource = jcrResourceProvider.getResource(ctx, PathUtils.ROOT_PATH, ResourceContext.EMPTY_CONTEXT, null);
-        Resource parentResource = jcrResourceProvider.getResource(ctx, parentNode.getPath(), ResourceContext.EMPTY_CONTEXT, rootResource);
-        Resource childResource = jcrResourceProvider.getResource(ctx, child.getPath(), ResourceContext.EMPTY_CONTEXT, parentResource);
-        Resource grandChildResource = jcrResourceProvider.getResource(ctx, grandchild.getPath(), ResourceContext.EMPTY_CONTEXT, childResource);
+        Resource rootResource =
+                jcrResourceProvider.getResource(ctx, PathUtils.ROOT_PATH, ResourceContext.EMPTY_CONTEXT, null);
+        Resource parentResource =
+                jcrResourceProvider.getResource(ctx, parentNode.getPath(), ResourceContext.EMPTY_CONTEXT, rootResource);
+        Resource childResource =
+                jcrResourceProvider.getResource(ctx, child.getPath(), ResourceContext.EMPTY_CONTEXT, parentResource);
+        Resource grandChildResource = jcrResourceProvider.getResource(
+                ctx, grandchild.getPath(), ResourceContext.EMPTY_CONTEXT, childResource);
         assertResources(rootResource, parentResource, childResource, grandChildResource);
 
         assertParent(jcrResourceProvider.getParent(ctx, grandChildResource), child.getPath());
@@ -165,11 +170,11 @@ public class JcrResourceProviderTest extends SlingRepositoryTestBase {
         Resource parent = jcrResourceProvider.getParent(mockResolveContext(), r);
         assertFalse(parent instanceof JcrNodeResource);
     }
-    
+
     @Test
     public void testGetNodeType() throws RepositoryException {
-        
-        Map<String,Object> properties = new HashMap<>();
+
+        Map<String, Object> properties = new HashMap<>();
         ResolveContext<JcrProviderState> context = mock(ResolveContext.class);
         // wire a mock jcrProviderState into the existing session (backed by a real repo)
         JcrProviderState jcrProviderState = mock(JcrProviderState.class);
@@ -177,49 +182,49 @@ public class JcrResourceProviderTest extends SlingRepositoryTestBase {
         when(jcrProviderState.getSession()).thenReturn(session);
 
         assertEquals(null, JcrResourceProvider.getNodeType(null, null));
-        properties.put("sling:alias","alias");
+        properties.put("sling:alias", "alias");
         assertEquals(null, JcrResourceProvider.getNodeType(properties, context));
         properties.put(JcrConstants.JCR_PRIMARYTYPE, "nt:unstructured");
         assertEquals("nt:unstructured", JcrResourceProvider.getNodeType(properties, context));
-        
+
         properties.clear();
         properties.put(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, "components/page");
         assertEquals(null, JcrResourceProvider.getNodeType(properties, context));
-        
+
         properties.put(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, "nt:unstructured");
         assertEquals("nt:unstructured", JcrResourceProvider.getNodeType(properties, context));
-        
+
         properties.put(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, "undefined:nodetype");
         assertEquals(null, JcrResourceProvider.getNodeType(properties, context));
     }
-    
-    @Test(expected=PersistenceException.class)
+
+    @Test(expected = PersistenceException.class)
     public void createWithNullPath() throws PersistenceException {
         jcrResourceProvider.create(null, null, null);
     }
-    
+
     @Test
     public void createResourceBelowRoot() throws PersistenceException, RepositoryException {
-        
-        Map<String,Object> properties = new HashMap<>();
+
+        Map<String, Object> properties = new HashMap<>();
         properties.put(JcrConstants.JCR_PRIMARYTYPE, "nt:file");
-        
+
         ResolveContext<JcrProviderState> context = mock(ResolveContext.class);
         JcrProviderState jcrProviderState = mock(JcrProviderState.class);
         when(context.getProviderState()).thenReturn(jcrProviderState);
         when(jcrProviderState.getSession()).thenReturn(session);
-        
+
         JcrNodeResource child = (JcrNodeResource) jcrResourceProvider.create(context, "/childnode", properties);
         assertNotNull(child);
         assertEquals("/childnode", child.getPath());
         assertEquals("nt:file", child.getItem().getPrimaryNodeType().getName());
-        
+
         properties.put("jcr:createdBy", "user");
-        JcrNodeResource grandchild = (JcrNodeResource) jcrResourceProvider.create(context, "/childnode/grandchild", properties);
+        JcrNodeResource grandchild =
+                (JcrNodeResource) jcrResourceProvider.create(context, "/childnode/grandchild", properties);
         assertNotNull(grandchild);
         assertEquals("/childnode/grandchild", grandchild.getPath());
-        assertEquals("admin",grandchild.getItem().getProperty("jcr:createdBy").getString());
-        
+        assertEquals("admin", grandchild.getItem().getProperty("jcr:createdBy").getString());
     }
 
     @Test
@@ -230,17 +235,23 @@ public class JcrResourceProviderTest extends SlingRepositoryTestBase {
 
         Node referenceable = JcrUtils.getOrCreateByPath("/root/referenceable", JcrConstants.NT_UNSTRUCTURED, session);
         referenceable.addMixin(JcrConstants.MIX_REFERENCEABLE);
-        Node nonReferenceable = JcrUtils.getOrCreateByPath("/root/non-referenceable", JcrConstants.NT_UNSTRUCTURED,
-                session);
+        Node nonReferenceable =
+                JcrUtils.getOrCreateByPath("/root/non-referenceable", JcrConstants.NT_UNSTRUCTURED, session);
         session.save();
 
-        Resource referenceableResource = jcrResourceProvider.getResource(mockResolveContext(),
-                JcrItemResourceFactory.SEARCH_BY_ID_PREFIX + referenceable.getIdentifier(), ResourceContext.EMPTY_CONTEXT, null);
+        Resource referenceableResource = jcrResourceProvider.getResource(
+                mockResolveContext(),
+                JcrItemResourceFactory.SEARCH_BY_ID_PREFIX + referenceable.getIdentifier(),
+                ResourceContext.EMPTY_CONTEXT,
+                null);
         assertNotNull(referenceableResource);
         assertEquals(referenceableResource.getPath(), referenceable.getPath());
 
-        Resource nonReferenceableResource = jcrResourceProvider.getResource(mockResolveContext(),
-                JcrItemResourceFactory.SEARCH_BY_ID_PREFIX + nonReferenceable.getIdentifier(), ResourceContext.EMPTY_CONTEXT, null);
+        Resource nonReferenceableResource = jcrResourceProvider.getResource(
+                mockResolveContext(),
+                JcrItemResourceFactory.SEARCH_BY_ID_PREFIX + nonReferenceable.getIdentifier(),
+                ResourceContext.EMPTY_CONTEXT,
+                null);
         assertNotNull(nonReferenceableResource);
         assertEquals(nonReferenceableResource.getPath(), nonReferenceable.getPath());
     }
@@ -249,19 +260,24 @@ public class JcrResourceProviderTest extends SlingRepositoryTestBase {
     public void getResourceByIdentifierConfigurationNotEnabled() throws RepositoryException {
         Node referenceable = JcrUtils.getOrCreateByPath("/root/referenceable", JcrConstants.NT_UNSTRUCTURED, session);
         referenceable.addMixin(JcrConstants.MIX_REFERENCEABLE);
-        Node nonReferenceable = JcrUtils.getOrCreateByPath("/root/non-referenceable", JcrConstants.NT_UNSTRUCTURED,
-                session);
+        Node nonReferenceable =
+                JcrUtils.getOrCreateByPath("/root/non-referenceable", JcrConstants.NT_UNSTRUCTURED, session);
         session.save();
 
-        Resource referenceableResource = jcrResourceProvider.getResource(mockResolveContext(),
-                JcrItemResourceFactory.SEARCH_BY_ID_PREFIX + referenceable.getIdentifier(), ResourceContext.EMPTY_CONTEXT, null);
+        Resource referenceableResource = jcrResourceProvider.getResource(
+                mockResolveContext(),
+                JcrItemResourceFactory.SEARCH_BY_ID_PREFIX + referenceable.getIdentifier(),
+                ResourceContext.EMPTY_CONTEXT,
+                null);
         assertNull(referenceableResource);
 
-        Resource nonReferenceableResource = jcrResourceProvider.getResource(mockResolveContext(),
-                JcrItemResourceFactory.SEARCH_BY_ID_PREFIX + nonReferenceable.getIdentifier(), ResourceContext.EMPTY_CONTEXT, null);
+        Resource nonReferenceableResource = jcrResourceProvider.getResource(
+                mockResolveContext(),
+                JcrItemResourceFactory.SEARCH_BY_ID_PREFIX + nonReferenceable.getIdentifier(),
+                ResourceContext.EMPTY_CONTEXT,
+                null);
         assertNull(nonReferenceableResource);
     }
-    
 
     private static void assertResources(Resource... resources) {
         for (Resource r : resources) {
@@ -276,5 +292,3 @@ public class JcrResourceProviderTest extends SlingRepositoryTestBase {
         assertEquals(expectedPath, parent.getPath());
     }
 }
-
-

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrTestNodeResource.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/JcrTestNodeResource.java
@@ -18,19 +18,23 @@
  */
 package org.apache.sling.jcr.resource.internal.helper.jcr;
 
-import java.util.concurrent.atomic.AtomicReference;
-
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
+
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.jcr.resource.internal.HelperData;
 
 public class JcrTestNodeResource extends JcrNodeResource {
 
-    public JcrTestNodeResource(ResourceResolver resourceResolver, Node node,
-                               ClassLoader dynamicClassLoader) throws RepositoryException {
-        super(resourceResolver, node.getPath(), null, node, new HelperData(new AtomicReference<>(), new AtomicReference<>()));
+    public JcrTestNodeResource(ResourceResolver resourceResolver, Node node, ClassLoader dynamicClassLoader)
+            throws RepositoryException {
+        super(
+                resourceResolver,
+                node.getPath(),
+                null,
+                node,
+                new HelperData(new AtomicReference<>(), new AtomicReference<>()));
     }
-
 }

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/SlingRepositoryProvider.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/SlingRepositoryProvider.java
@@ -30,10 +30,9 @@ public class SlingRepositoryProvider {
 
     private static OakMockSlingRepository INSTANCE;
 
-    private SlingRepositoryProvider() {
-    }
+    private SlingRepositoryProvider() {}
 
-    public synchronized static SlingRepository getRepository() throws Exception {
+    public static synchronized SlingRepository getRepository() throws Exception {
         if (INSTANCE == null) {
             OakMockSlingRepository r = new OakMockSlingRepository();
             Method activateMethod = OakMockSlingRepository.class.getDeclaredMethod("activate", BundleContext.class);
@@ -44,13 +43,11 @@ public class SlingRepositoryProvider {
         return INSTANCE;
     }
 
-
     public static void shutdown() throws Exception {
         Method deactivateMethod = OakMockSlingRepository.class.getDeclaredMethod("deactivate", ComponentContext.class);
         deactivateMethod.setAccessible(true);
         deactivateMethod.invoke(getRepository(), (ComponentContext) null);
     }
-
 
     private static BundleContext getFakeContext() {
         return Mockito.mock(BundleContext.class);

--- a/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/SlingRepositoryTestBase.java
+++ b/src/test/java/org/apache/sling/jcr/resource/internal/helper/jcr/SlingRepositoryTestBase.java
@@ -21,12 +21,11 @@ package org.apache.sling.jcr.resource.internal.helper.jcr;
 import javax.jcr.Node;
 import javax.jcr.Session;
 
+import junit.framework.TestCase;
 import org.apache.sling.jcr.api.SlingRepository;
 
-import junit.framework.TestCase;
-
 public abstract class SlingRepositoryTestBase extends TestCase {
-    
+
     protected Node testRoot;
     protected Session session;
     private int counter;
@@ -46,7 +45,7 @@ public abstract class SlingRepositoryTestBase extends TestCase {
         }
         return session;
     }
-    
+
     /** Return a test root node, created on demand, with a unique path */
     protected Node getTestRootNode() throws Exception {
         if (testRoot == null) {
@@ -57,13 +56,9 @@ public abstract class SlingRepositoryTestBase extends TestCase {
         return testRoot;
     }
 
-    /** Return a Repository 
+    /** Return a Repository
      * @throws Exception */
     protected SlingRepository getRepository() throws Exception {
         return SlingRepositoryProvider.getRepository();
     }
-
-    
-
-
 }


### PR DESCRIPTION
Upgrades the Maven parent POM from version 52 to 66 and applies housekeeping changes across the module.

**Changes:**
- Bump `sling-bundle-parent` from `52` to `66`
- Add `<sling.java.version>8</sling.java.version>` property
- Change POM encoding declaration from ISO-8859-1 to UTF-8
- Reorder import groups in Java files to place `javax.*` before `java.*` (Sling convention)
- Reformat long constructor/method signatures to one-parameter-per-line style
- Move `<build>` section to after `<dependencies>` in POM
- Minor POM formatting: SCM indentation, description inline, comment placement
- Add missing newline at end of `JcrResourceChange.java`
- Remove trailing blank lines in `package-info.java`

Co-authored-by: Maia <maia@noreply>